### PR TITLE
CUDA finish

### DIFF
--- a/cl_manycore/libraries/bsg_manycore_driver.cpp
+++ b/cl_manycore/libraries/bsg_manycore_driver.cpp
@@ -439,6 +439,30 @@ int hb_mc_init_device (uint8_t fd, eva_id_t eva_id, char *elf, tile_t *tiles, ui
 	return HB_MC_SUCCESS;
 }
 
+/*!
+ * Initializes Manycore tiles so that they may run kernels.
+ * @param fd userspace file descriptor
+ * @param eva_id specifies what the EVA-NPA mapping is.
+ * @param tiles an array of tile_t structs to initialize.
+ * @param num_tiles the number of tiles to initialize.
+ * @return HB_MC_SUCCESS on success and HB_MC_FAIL on failure. 
+ */
+int hb_mc_device_finish (uint8_t fd, eva_id_t eva_id, tile_t *tiles, uint32_t num_tiles) {
+	if (eva_id != 0) {
+		return HB_MC_FAIL; /* eva_id not supported */
+	} 
+
+	else if (!mem_manager[eva_id])
+		return HB_MC_SUCCESS; /* there is no memory manager to deinitialize */
+	
+	delete(mem_manager[eva_id]);
+	
+	for (int i = 0; i < num_tiles; i++) { /* freeze tiles */
+		hb_mc_freeze(fd, tiles[i].x, tiles[i].y);
+	}
+
+	return HB_MC_SUCCESS;
+}
 #ifdef COSIM
 /*!
  * This function is for testing hb_mc_init_device() in cosimulation. 
@@ -451,4 +475,7 @@ void _hb_mc_get_mem_manager_info(eva_id_t eva_id, uint32_t *start, uint32_t *siz
 	*start = mem_manager[eva_id]->start();
 	*size =mem_manager[eva_id]->size();
 }
+
+
+
 #endif

--- a/cl_manycore/libraries/bsg_manycore_driver.h
+++ b/cl_manycore/libraries/bsg_manycore_driver.h
@@ -49,6 +49,7 @@ uint8_t hb_mc_get_num_x ();
 uint8_t hb_mc_get_num_y (); 
 void hb_mc_format_request_packet(hb_mc_request_packet_t *packet, uint32_t addr, uint32_t data, uint8_t x, uint8_t y, uint8_t opcode);
 int hb_mc_init_device (uint8_t fd, eva_id_t eva_id, char *elf, tile_t *tiles, uint32_t num_tiles);
+int hb_mc_device_finish (uint8_t fd, eva_id_t eva_id, tile_t *tiles, uint32_t num_tiles);
 #ifdef COSIM
 void _hb_mc_get_mem_manager_info(eva_id_t eva_id, uint32_t *start, uint32_t *size); /* TODO: Remove; this is for testing only */
 #endif

--- a/cl_manycore/software/cosim_device_init_test.h
+++ b/cl_manycore/software/cosim_device_init_test.h
@@ -41,15 +41,17 @@ void cosim_device_init_test () {
 	tiles[0].origin_x = 0;
 	tiles[0].origin_y = 1;
 	eva_id_t eva_id = 0;
-	
-	if (hb_mc_init_device(fd, eva_id, getenv("MAIN_LOOPBACK"), &tiles[0], 1) != HB_MC_SUCCESS) {
+	uint32_t num_tiles = 1;
+	if (hb_mc_init_device(fd, eva_id, getenv("MAIN_LOOPBACK"), &tiles[0], num_tiles) != HB_MC_SUCCESS) {
 		printf("could not initialize device.\n");
 		return;
 	}  
 
+	/* make sure memory manager was initialized properly */
 	uint32_t start, size;
 	_hb_mc_get_mem_manager_info(eva_id, &start, &size); 
 	printf("start: 0x%x, size: 0x%x\n", start, size);
+	hb_mc_device_finish(fd, eva_id, tiles, num_tiles);
 	return;
 }
 


### PR DESCRIPTION
I have added a finish function as described in Issue #43.  Its purpose is to call the deconstructor of an `awsbwhal::MemoryManager` object.

`bsg_manycore`: `ff0c069`, `bsg_ip_cores`: `47e23d7`