### PR TITLE
CUDA malloc

### DIFF
--- a/cl_manycore/libraries/bsg_manycore_driver.cpp
+++ b/cl_manycore/libraries/bsg_manycore_driver.cpp
@@ -475,7 +475,22 @@ void _hb_mc_get_mem_manager_info(eva_id_t eva_id, uint32_t *start, uint32_t *siz
 	*start = mem_manager[eva_id]->start();
 	*size =mem_manager[eva_id]->size();
 }
-
-
-
 #endif
+
+/*!
+ * allocates memory in Manycore
+ *@param eva_id specifies EVA-NPA mapping.
+ *@param size in bytes.
+ *@return an EVA address. On failure, 0 will be returned. 
+ */
+eva_t hb_mc_device_malloc (eva_id_t eva_id, uint32_t size) {
+	if (eva_id != 0) {
+		return 0; /* invalid EVA ID */
+	}
+	else if (!mem_manager[eva_id]) {
+		return 0; /* memory manager has not been initialized */
+	}
+
+	eva_t result = mem_manager[eva_id]->alloc(size);
+	return result;
+}

--- a/cl_manycore/libraries/bsg_manycore_driver.h
+++ b/cl_manycore/libraries/bsg_manycore_driver.h
@@ -50,6 +50,7 @@ uint8_t hb_mc_get_num_y ();
 void hb_mc_format_request_packet(hb_mc_request_packet_t *packet, uint32_t addr, uint32_t data, uint8_t x, uint8_t y, uint8_t opcode);
 int hb_mc_init_device (uint8_t fd, eva_id_t eva_id, char *elf, tile_t *tiles, uint32_t num_tiles);
 int hb_mc_device_finish (uint8_t fd, eva_id_t eva_id, tile_t *tiles, uint32_t num_tiles);
+eva_t hb_mc_device_malloc (eva_id_t eva_id, uint32_t size);
 #ifdef COSIM
 void _hb_mc_get_mem_manager_info(eva_id_t eva_id, uint32_t *start, uint32_t *size); /* TODO: Remove; this is for testing only */
 #endif

--- a/cl_manycore/software/cl_manycore.c
+++ b/cl_manycore/software/cl_manycore.c
@@ -23,7 +23,7 @@
 #include "cosim_read_write_test.h"
 #include "cosim_load_vector_test.h"
 #include "cosim_loopback_test.h"
-#include "cosim_device_init_test.h"
+#include "cosim_cuda_test.h"
 
 #ifdef SV_TEST
     #include "fpga_pci_sv.h"
@@ -125,7 +125,7 @@ void usage(char* program_name) {
     cosim_load_vector_test();
     cosim_loopback_test();
     cosim_rom_test();
-    cosim_device_init_test();
+    cosim_cuda_test();
 #ifndef SV_TEST
     return rc;
      

--- a/cl_manycore/software/cosim_cuda_test.h
+++ b/cl_manycore/software/cosim_cuda_test.h
@@ -1,5 +1,5 @@
-#ifndef COSIM_DEVICE_INIT_TEST_iH
-#define COSIM_DEVICE_INIT_TEST_H
+#ifndef COSIM_CUDA_TEST_H
+#define COSIM_CUDA_TEST_H
 
 #ifndef _BSD_SOURCE
 	#define _BSD_SOURCE
@@ -28,7 +28,7 @@ void print_hex (uint8_t *p) {
 }
 
 
-void cosim_device_init_test () {
+void cosim_cuda_test () {
 	
 	printf("Cosimulation test of hb_mc_init_device().\n\n");
 	uint8_t fd; 
@@ -51,6 +51,12 @@ void cosim_device_init_test () {
 	uint32_t start, size;
 	_hb_mc_get_mem_manager_info(eva_id, &start, &size); 
 	printf("start: 0x%x, size: 0x%x\n", start, size);
+	
+	/* allocate 2 64B buffers */
+	eva_t A = hb_mc_device_malloc(eva_id, 64);
+	eva_t B = hb_mc_device_malloc(eva_id, 64);
+	printf("A's EVA 0x%x, B's EVA: 0x%x\n", A, B);
+	
 	hb_mc_device_finish(fd, eva_id, tiles, num_tiles);
 	return;
 }


### PR DESCRIPTION
This PR addresses Issue #40.  I have implemented 

- a device malloc function

- a cosimulation script for testing it. The test allocates 2 64B buffers and prints their addresses. 

`bsg_manycore`: `d78107c`, `bsg_ip_cores`: `47e23d7`