### PR TITLE
CUDA free

### DIFF
--- a/cl_manycore/libraries/bsg_manycore_driver.cpp
+++ b/cl_manycore/libraries/bsg_manycore_driver.cpp
@@ -497,6 +497,23 @@ eva_t hb_mc_device_malloc (eva_id_t eva_id, uint32_t size) {
 	return result;
 }
 
+/*!
+ * frees Hammerblade Manycore memory.
+ *@param eva_id specifies EVA-NPA mapping.
+ *@param eva address to free.
+ *@return HB_MC_SUCCESS on success and HB_MC_FAIL on failure. This function can fail if eva_id is invalid or of the memory manager corresponding to eva_id has not been initialized.
+ */
+int hb_mc_device_free (eva_id_t eva_id, eva_t eva) {
+	if (eva_id != 0) {
+		return HB_MC_FAIL; /* invalid EVA ID */
+	}
+	else if (!mem_manager[eva_id]) {
+		return HB_MC_FAIL; /* memory manager has not been initialized */
+	}
+
+	mem_manager[eva_id]->free(eva);
+	return HB_MC_SUCCESS;
+}
 
 /* returns desired bits aligned to the LSB.
  * */

--- a/cl_manycore/libraries/bsg_manycore_driver.h
+++ b/cl_manycore/libraries/bsg_manycore_driver.h
@@ -57,6 +57,7 @@ void hb_mc_format_request_packet(hb_mc_request_packet_t *packet, uint32_t addr, 
 int hb_mc_init_device (uint8_t fd, eva_id_t eva_id, char *elf, tile_t *tiles, uint32_t num_tiles);
 int hb_mc_device_finish (uint8_t fd, eva_id_t eva_id, tile_t *tiles, uint32_t num_tiles);
 eva_t hb_mc_device_malloc (eva_id_t eva_id, uint32_t size);
+int hb_mc_device_free (eva_id_t eva_id, eva_t eva);
 int hb_mc_eva_to_npa (eva_id_t eva_id, eva_t eva, npa_t *npa);
 #ifdef COSIM
 void _hb_mc_get_mem_manager_info(eva_id_t eva_id, uint32_t *start, uint32_t *size); /* TODO: Remove; this is for testing only */

--- a/cl_manycore/software/cl_manycore.c
+++ b/cl_manycore/software/cl_manycore.c
@@ -24,7 +24,6 @@
 #include "cosim_load_vector_test.h"
 #include "cosim_loopback_test.h"
 #include "cosim_cuda_test.h"
-
 #ifdef SV_TEST
     #include "fpga_pci_sv.h"
 #else

--- a/cl_manycore/software/cosim_cuda_test.h
+++ b/cl_manycore/software/cosim_cuda_test.h
@@ -21,7 +21,6 @@
 #include "bsg_manycore_errno.h"
 
 void cosim_cuda_test () {
-	
 	printf("Cosimulation test of hb_mc_init_device().\n\n");
 	uint8_t fd; 
 	hb_mc_init_host(&fd);
@@ -99,7 +98,8 @@ void cosim_cuda_test () {
 	}		
 
 	/* free A and B on device */
-	/* TODO */
+	hb_mc_device_free(eva_id, A_device);
+	hb_mc_device_free(eva_id, B_device);
 
 	hb_mc_device_finish(fd, eva_id, tiles, num_tiles);
 	return;


### PR DESCRIPTION
The free function allows the user to free Hammerblade Manycore memory (Issue #55). 

Use `bsg_manycore d78107c` and `bsg_ip_cores 47e23d7`.
