### PR TITLE
memcpy no longer expects dst to be a buffer of response packets when

### DIFF
--- a/cl_manycore/examples/run_kernel_add.c
+++ b/cl_manycore/examples/run_kernel_add.c
@@ -127,7 +127,7 @@ int main (int argc, char *argv[]) {
 	hb_mc_cuda_sync (fd, &tiles[0]); /* if CUDA sync is correct, this program won't hang here. */
 
 
-	hb_mc_response_packet_t C_host[size_buffer];
+        uint32_t C_host[size_buffer];
 	src = (void *) C_device;
 	dst = (void *) &C_host[0];
 	error = hb_mc_device_memcpy (fd, eva_id, (void *) dst, src, size_buffer * sizeof(uint32_t), hb_mc_memcpy_to_host); /* copy A to the host */
@@ -137,7 +137,7 @@ int main (int argc, char *argv[]) {
 	
 	printf("Finished vector addition: \n");
 	for (int i = 0; i < size_buffer; i++) {
-		printf("A[%d] + B[%d] =  0x%x + 0x%x = 0x%x\n", i, i , A_host[i], B_host[i], hb_mc_response_packet_get_data(&C_host[i])); 
+		printf("A[%d] + B[%d] =  0x%x + 0x%x = 0x%x\n", i, i , A_host[i], B_host[i], C_host[i]);
 	}	
 
 	hb_mc_device_free(eva_id, A_device); /* free A on device */

--- a/cl_manycore/libraries/bsg_manycore_driver.cpp
+++ b/cl_manycore/libraries/bsg_manycore_driver.cpp
@@ -810,10 +810,15 @@ int hb_mc_device_memcpy (uint8_t fd, eva_id_t eva_id, void *dst, const void *src
 	else if (kind == hb_mc_memcpy_to_host) { /* copy to Host */
 		eva_t src_eva = (eva_t) reinterpret_cast<uintptr_t>(src);
 		for (int i = 0; i < count; i += sizeof(uint32_t)) { /* copy one word at a time */
-			hb_mc_response_packet_t *dst_packet = (hb_mc_response_packet_t *) dst + (i / sizeof(uint32_t));
-			int error = hb_mc_cpy_from_eva(fd, eva_id, dst_packet, src_eva + i); 		
+                        // read in a packet
+                        hb_mc_response_packet_t dst_packet;
+			int error = hb_mc_cpy_from_eva(fd, eva_id, &dst_packet, src_eva + i);
 			if (error != HB_MC_SUCCESS)
 				return HB_MC_FAIL; /* copy failed */
+
+                        // copy the word into caller dst buffer
+                        uint32_t *dst_w = (uint32_t*)dst;
+                        dst_w[i/sizeof(uint32_t)] = hb_mc_response_packet_get_data(&dst_packet);
 		}
 		return HB_MC_SUCCESS;	
 	}

--- a/cl_manycore/software/cosim_cuda_test.h
+++ b/cl_manycore/software/cosim_cuda_test.h
@@ -88,7 +88,7 @@ void cosim_cuda_test () {
 
 	hb_mc_cuda_sync(fd, &tiles[0]); /* if CUDA sync is correct, this program won't hang here. */
 	
-	hb_mc_response_packet_t C_host[size_buffer];
+	uint32_t C_host[size_buffer];
 	src = (void *) C_device;
 	dst = (void *) &C_host[0];
 	error = hb_mc_device_memcpy (fd, eva_id, (void *) dst, src, size_buffer * sizeof(uint32_t), hb_mc_memcpy_to_host); /* copy A to the host */
@@ -98,7 +98,7 @@ void cosim_cuda_test () {
 	
 	printf("Finished vector addition: \n");
 	for (int i = 0; i < size_buffer; i++) {
-		printf("A[%d] + B[%d] =  0x%x + 0x%x = 0x%x\n", i, i , A_host[i], B_host[i], hb_mc_response_packet_get_data(&C_host[i])); 
+		printf("A[%d] + B[%d] =  0x%x + 0x%x = 0x%x\n", i, i , A_host[i], B_host[i], C_host[i]);
 	}	
 
 	hb_mc_device_free(eva_id, A_device); /* free A on device */


### PR DESCRIPTION
This PR addresses issue #98 in which `hb_mc_memcpy` expected its `dst` argument to point to an array of `hb_mc_request_packet_t` sized to the number of 32-bit words to be read from the device. 

This PR changes removes that expectation. Callers may now pass any buffer large enough to hold `count` bytes.