### PR TITLE
adds cuda library source files to regression

### DIFF
--- a/cl_manycore/regression/spmd/spmd_tests.h
+++ b/cl_manycore/regression/spmd/spmd_tests.h
@@ -9,6 +9,7 @@
 #include "bsg_manycore_mem.h"
 #include "bsg_manycore_loader.h"
 #include "bsg_manycore_errno.h"	
+#include "bsg_manycore_cuda.h"
 
 #else // !COSIM
 
@@ -16,6 +17,7 @@
 #include <bsg_manycore_mem.h>
 #include <bsg_manycore_loader.h>
 #include <bsg_manycore_errno.h>
+#include <bsg_manycore_cuda.h>
 
 #endif // #ifdef COSIM
 

--- a/cl_manycore/testbenches/cosim/Makefile.common
+++ b/cl_manycore/testbenches/cosim/Makefile.common
@@ -42,6 +42,7 @@ C_LIB_SRC += $(CL_DIR)/libraries/bsg_manycore_elf.cpp
 C_LIB_SRC += $(CL_DIR)/libraries/bsg_manycore_loader.cpp
 C_LIB_SRC += $(CL_DIR)/libraries/bsg_manycore_mem.cpp 
 C_LIB_SRC += $(CL_DIR)/libraries/bsg_manycore_memory_manager.cpp
+C_LIB_SRC += $(CL_DIR)/libraries/bsg_manycore_cuda.cpp
 
 CFLAGS   = -DVIVADO_SIM -DCOSIM $(REGRESSION_DEFINES)
 INCLUDES = -I$(C_SDK_USR_INC_DIR) -I$(C_SDK_USR_UTILS_DIR)


### PR DESCRIPTION
The Cuda library was moved into it's own source and header file. This PR updates the regression test suite to account for this.