### PR TITLE
Added the routine to drain fifos on initialize and finish

### DIFF
--- a/cl_manycore/libraries/bsg_manycore_cuda.cpp
+++ b/cl_manycore/libraries/bsg_manycore_cuda.cpp
@@ -96,11 +96,12 @@ int hb_mc_init_device (uint8_t fd, eva_id_t eva_id, char *elf, tile_t *tiles, ui
 		return HB_MC_FAIL; /* eva_id not supported */
 	} 
 
+	hb_mc_drain_all_fifos(fd);
+
 	for (int i = 0; i < num_tiles; i++) { /* initialize tiles */
 		hb_mc_freeze(fd, tiles[i].x, tiles[i].y);
 		hb_mc_set_tile_group_origin(fd, tiles[i].x, tiles[i].y, tiles[i].origin_x, tiles[i].origin_y);
 	}
-
 
 	/* load the elf into each tile */
 	uint8_t x_list[num_tiles], y_list[num_tiles];	
@@ -142,6 +143,8 @@ int hb_mc_device_finish (uint8_t fd, eva_id_t eva_id, tile_t *tiles, uint32_t nu
 	for (int i = 0; i < num_tiles; i++) { /* freeze tiles */
 		hb_mc_freeze(fd, tiles[i].x, tiles[i].y);
 	}
+
+	hb_mc_drain_all_fifos(fd);
 
 	return HB_MC_SUCCESS;
 }

--- a/cl_manycore/libraries/bsg_manycore_driver.h
+++ b/cl_manycore/libraries/bsg_manycore_driver.h
@@ -42,7 +42,8 @@ typedef struct {
 	uint32_t epa;
 } npa_t;
 
-typedef enum __hb_mc_direction_t {
+typedef enum __hb_mc_direction_t {  /*MIN and MAX are not fifo directions, they are only for iteration over fifos. Update HB_MC_MMIO_FIFO_MAX if you add another FIFO direction.  */
+	HB_MC_MMIO_FIFO_MIN = 0,
 	HB_MC_MMIO_FIFO_TO_DEVICE = 0,
 	HB_MC_MMIO_FIFO_TO_HOST = 1,
 	HB_MC_MMIO_FIFO_MAX = 2
@@ -52,6 +53,7 @@ int hb_mc_check_dim (uint8_t fd);
 int hb_mc_write_fifo (uint8_t fd, hb_mc_direction_t dir, hb_mc_packet_t *packet);
 int hb_mc_get_fifo_occupancy (uint8_t fd, hb_mc_direction_t dir, uint32_t *occupancy_p);
 int hb_mc_read_fifo (uint8_t fd, hb_mc_direction_t dir, hb_mc_packet_t *packet);
+int hb_mc_drain_all_fifos(uint8_t fd);
 int hb_mc_clear_int (uint8_t fd, hb_mc_direction_t dir);
 int hb_mc_get_host_credits (uint8_t fd);
 int hb_mc_all_host_req_complete(uint8_t fd);


### PR DESCRIPTION
*** Only compatible with the magic number refactored version ***
For the F1 regression tests to be more reliable, added hb_mc_drain_all_fifos routine to remove any left-over packets from fifos on init_host, init_device and device_finish. 
Passed COSIM and F1 regression tests.