### PR TITLE
adds bsg_manycore_features.h

### DIFF
--- a/cl_manycore/libraries/Makefile
+++ b/cl_manycore/libraries/Makefile
@@ -14,6 +14,7 @@ HEADERS += bsg_manycore_bits.h
 HEADERS += bsg_manycore_elf.h
 HEADERS += bsg_manycore_memory_manager.h
 HEADERS += bsg_manycore_cuda.h
+HEADERS += bsg_manycore_features.h
 
 OBJECTS := bsg_manycore_driver.o
 OBJECTS += bsg_manycore_loader.o

--- a/cl_manycore/libraries/bsg_manycore_bits.h
+++ b/cl_manycore/libraries/bsg_manycore_bits.h
@@ -1,6 +1,10 @@
 #ifndef BSG_MANYCORE_BITS_H
 #define BSG_MANYCORE_BITS_H
-
+#ifndef COSIM
+#include <bsg_manycore_features.h>
+#else
+#include "bsg_manycore_features.h"
+#endif
 #include <stdint.h>
 
 #ifdef __cplusplus

--- a/cl_manycore/libraries/bsg_manycore_cuda.h
+++ b/cl_manycore/libraries/bsg_manycore_cuda.h
@@ -1,20 +1,15 @@
 #ifndef BSG_MANYCORE_CUDA_H
 #define BSG_MANYCORE_CUDA_H
 
-#ifndef _BSD_SOURCE
-	#define _BSD_SOURCE
-#endif
-#ifndef _XOPEN_SOURCE
-	#define _XOPEN_SOURCE 500
+#ifndef COSIM
+#include <bsg_manycore_features.h>
+#include <bsg_manycore_mem.h>
+#else
+#include "bsg_manycore_features.h"
+#include "bsg_manycore_mem.h"
 #endif
 
 #include <stdint.h>
-
-#ifndef COSIM
-#include <bsg_manycore_mem.h>
-#else
-#include "bsg_manycore_mem.h"
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/cl_manycore/libraries/bsg_manycore_driver.h
+++ b/cl_manycore/libraries/bsg_manycore_driver.h
@@ -1,22 +1,17 @@
 #ifndef BSG_MANYCORE_DRIVER_H
 #define BSG_MANYCORE_DRIVER_H
 
-#ifndef _BSD_SOURCE
-	#define _BSD_SOURCE
-#endif
-#ifndef _XOPEN_SOURCE
-	#define _XOPEN_SOURCE 500
-#endif
-
-#include <endian.h>
-#include <stdint.h>
 #ifndef COSIM
+        #include <bsg_manycore_features.h>
         #include <bsg_manycore_errno.h>
 	#include <bsg_manycore_bits.h>
 #else
+        #include "bsg_manycore_features.h"
         #include "bsg_manycore_errno.h"
 	#include "bsg_manycore_bits.h"
 #endif
+#include <endian.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/cl_manycore/libraries/bsg_manycore_elf.h
+++ b/cl_manycore/libraries/bsg_manycore_elf.h
@@ -5,8 +5,10 @@
 extern "C" {
 #endif
 #ifndef COSIM
+#include <bsg_manycore_features.h>
 #include <bsg_manycore_mem.h>
 #else
+#include "bsg_manycore_features.h"
 #include "bsg_manycore_mem.h"
 #endif
 

--- a/cl_manycore/libraries/bsg_manycore_errno.h
+++ b/cl_manycore/libraries/bsg_manycore_errno.h
@@ -1,6 +1,10 @@
 #ifndef BSG_MANYCORE_ERRNO
 #define BSG_MANYCORE_ERRNO
-
+#ifndef COSIM
+#include <bsg_manycore_features.h>
+#else
+#include "bsg_manycore_features.h"
+#endif
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cl_manycore/libraries/bsg_manycore_features.h
+++ b/cl_manycore/libraries/bsg_manycore_features.h
@@ -1,0 +1,19 @@
+#ifndef BSG_MANYCORE_FEATURES_H
+#define BSG_MANYCORE_FEATURES_H
+// <features.h> sorts out many of these defines based on compile time flags (e.g. -std=c++11)
+#include <features.h>
+// check _BSG_SOURCE
+#ifndef _BSD_SOURCE
+#error "_BSG_SOURCE not defined: required for bsg_manycore_runtime"
+#endif
+
+// check _XOPEN_SOURCE
+#ifndef _XOPEN_SOURCE
+#error "_XOPEN_SOURCE not defined: required for bsg_manycore_runtime"
+#else
+#if _XOPEN_SOURCE < 500
+#error "_XOPEN_SOURCE < 500: bsg_manycore_runtime requires _XOPEN_SOURCE >= 500"
+#endif
+#endif
+
+#endif

--- a/cl_manycore/libraries/bsg_manycore_loader.h
+++ b/cl_manycore/libraries/bsg_manycore_loader.h
@@ -8,6 +8,22 @@
 	#define _XOPEN_SOURCE 500
 #endif
 
+#ifndef COSIM
+        #include <bsg_manycore_features.h>
+	#include <bsg_manycore_driver.h>
+	#include <bsg_manycore_tile.h>
+	#include <bsg_manycore_errno.h>
+	#include <bsg_manycore_mmio.h>
+	#include <bsg_manycore_mem.h>
+#else
+	#include <utils/sh_dpi_tasks.h>
+        #include "bsg_manycore_features.h"
+	#include "bsg_manycore_driver.h"
+	#include "bsg_manycore_tile.h"
+	#include "bsg_manycore_errno.h"
+	#include "bsg_manycore_mmio.h"
+	#include "bsg_manycore_mem.h"
+#endif
 #include "elf.h"
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -19,20 +35,6 @@
 #include <stdio.h>
 #include <limits.h>
 #include <stdbool.h>
-#ifndef COSIM
-	#include <bsg_manycore_driver.h>
-	#include <bsg_manycore_tile.h>
-	#include <bsg_manycore_errno.h>
-	#include <bsg_manycore_mmio.h>
-	#include <bsg_manycore_mem.h>
-#else
-	#include <utils/sh_dpi_tasks.h>
-	#include "bsg_manycore_driver.h"
-	#include "bsg_manycore_tile.h"
-	#include "bsg_manycore_errno.h"
-	#include "bsg_manycore_mmio.h"
-	#include "bsg_manycore_mem.h"
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/cl_manycore/libraries/bsg_manycore_mem.h
+++ b/cl_manycore/libraries/bsg_manycore_mem.h
@@ -1,20 +1,21 @@
 #ifndef BSG_MANYCORE_MEM_H
 #define BSG_MANYCORE_MEM_H
 
-#ifndef _BSD_SOURCE
-	#define _BSD_SOURCE
-#endif
-#ifndef _XOPEN_SOURCE
-	#define _XOPEN_SOURCE 500
-#endif
-
-#include <stdint.h>
+/* #ifndef _BSD_SOURCE */
+/* 	#define _BSD_SOURCE */
+/* #endif */
+/* #ifndef _XOPEN_SOURCE */
+/* 	#define _XOPEN_SOURCE 500 */
+/* #endif */
 
 #ifndef COSIM
+#include <bsg_manycore_features.h>
 #include <bsg_manycore_driver.h>
 #else
+#include "bsg_manycore_features.h"
 #include "bsg_manycore_driver.h"
 #endif 
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/cl_manycore/libraries/bsg_manycore_memory_manager.h
+++ b/cl_manycore/libraries/bsg_manycore_memory_manager.h
@@ -20,6 +20,12 @@
 #ifndef _XDMA_MEMORY_MANAGER_H_
 #define _XDMA_MEMORY_MANAGER_H_
 
+#ifndef COSIM
+#include <bsg_manycore_features.h>
+#else
+#include "bsg_manycore_features.h"
+#endif
+
 #include <mutex>
 #include <list>
 #include "xclhal.h"

--- a/cl_manycore/libraries/bsg_manycore_mmio.h
+++ b/cl_manycore/libraries/bsg_manycore_mmio.h
@@ -1,6 +1,12 @@
 #ifndef BSG_MANYCORE_MMIO
 #define BSG_MANYCORE_MMIO
 
+#ifndef COSIM
+#include <bsg_manycore_features.h>
+#else
+#include "bsg_manycore_features.h"
+#endif
+
 /* PCIe FIFOs */
 // From https://www.xilinx.com/support/documentation/ip_documentation/axi_fifo_mm_s/v4_1/pg080-axi-fifo-mm-s.pdf
 #define HB_MC_MMIO_FIFO_TX_VACANCY_OFFSET 0xC

--- a/cl_manycore/libraries/bsg_manycore_tile.h
+++ b/cl_manycore/libraries/bsg_manycore_tile.h
@@ -1,21 +1,17 @@
 #ifndef BSG_MANYCORE_TILE_H
 #define BSG_MANYCORE_TILE_H
 
-#ifndef _BSD_SOURCE
-	#define _BSD_SOURCE
-#endif
-#ifndef _XOPEN_SOURCE
-	#define _XOPEN_SOURCE 500
-#endif
-
-#include <stdint.h>
 #ifndef COSIM
+#include <bsg_manycore_features.h>
 #include <bsg_manycore_driver.h>
 #include <bsg_manycore_mem.h>
 #else
+#include "bsg_manycore_features.h"
 #include "bsg_manycore_driver.h"
 #include "bsg_manycore_mem.h"
 #endif
+
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/cl_manycore/regression/Makefile.common
+++ b/cl_manycore/regression/Makefile.common
@@ -1,4 +1,4 @@
-CFLAGS   = -std=c11 $(REGRESSION_DEFINES)
+CFLAGS   = -std=c11 -D_XOPEN_SOURCE=500 -D_BSD_SOURCE $(REGRESSION_DEFINES)
 CXXFLAGS = -std=c++11 -pthread -O0 $(REGRESSION_DEFINES)
 LDFLAGS  = -lbsg_manycore_runtime
 

--- a/cl_manycore/regression/spmd/spmd_tests.h
+++ b/cl_manycore/regression/spmd/spmd_tests.h
@@ -18,7 +18,6 @@
 #include <bsg_manycore_mem.h>
 #include <bsg_manycore_loader.h>
 #include <bsg_manycore_errno.h>
-
 #endif // #ifdef COSIM
 
 #include "../cl_manycore_regression.h"

--- a/cl_manycore/testbenches/cosim/Makefile.common
+++ b/cl_manycore/testbenches/cosim/Makefile.common
@@ -45,7 +45,7 @@ C_LIB_SRC += $(CL_DIR)/libraries/bsg_manycore_mem.cpp
 C_LIB_SRC += $(CL_DIR)/libraries/bsg_manycore_memory_manager.cpp
 C_LIB_SRC += $(CL_DIR)/libraries/bsg_manycore_tile.cpp
 
-CFLAGS   = -DVIVADO_SIM -DCOSIM $(REGRESSION_DEFINES)
+CFLAGS   = -DVIVADO_SIM -DCOSIM $(REGRESSION_DEFINES) -D_XOPEN_SOURCE=500 -D_BSD_SOURCE
 INCLUDES = -I$(C_SDK_USR_INC_DIR) -I$(C_SDK_USR_UTILS_DIR)
 INCLUDES += -I$(C_COMMON_DIR)/include -I$(TESTS_PATH) -I$(CL_DIR)/libraries -I$(AWS_FPGA_REPO_DIR)/SDAccel/userspace/include
 


### PR DESCRIPTION
* This addresses an issue observed when compiling the regressions tests `htole32 undefined`
* This issue occurs when client source files include standard system headers before including `big_manycore_*` headers. 
* This PR addresses the issue by creating a file `bsg_manycore_features.h` which acts as a guard to check that needed C standards are defined. If they are not then the compilation errors out.
* As a result the client will know to add these defines to  their`CFLAGS` variable instead of being confused by linker errors.
* <b> For this fix to work in the future every new library header should include `bsg_manycore_features.h` before any other header</b>
* This PR <b>does not address</b> an outstanding issue in which an invalid file descriptor is passed to `format_packet` and causes the regression tests to fail.