### PR TITLE
Added Makefile code to check for/include for Bladerunner Makefiles

### DIFF
--- a/cl_manycore/Makefile.environment
+++ b/cl_manycore/Makefile.environment
@@ -6,6 +6,23 @@ ifndef CL_DIR
 $(error "CL_DIR undefined. Set CL_DIR before running this makefile")
 endif
 
+# Default to overriding BSG_IP_CORES_DIR and BSG_MANYCORE_DIR and warn
+ifneq ("$(wildcard ../../Makefile.deps)","")
+ORANGE=\033[0;33m
+NC=\033[0m
+
+ifdef BSG_IP_CORES_DIR
+$(warning $(shell echo -e "\t\n\t$(ORANGE)Overriding BSG_IP_CORES_DIR environment variable with Bladerunner defaults.$(NC)"))
+endif
+
+ifdef BSG_MANYCORE_DIR
+$(warning $(shell echo -e "\t\n\t$(ORANGE)Overriding BSG_MANYCORE_DIR environment variable with Bladerunner defaults.$(NC)"))
+endif
+
+include ../../Makefile.common
+
+endif
+
 ifndef BSG_IP_CORES_DIR
 $(error "BSG_IP_CORES_DIR environment variable undefined.")
 endif


### PR DESCRIPTION
* Sets BASEJUMP_STL_DIR BSG_IP_CORES_DIR BSG_MANYCORE_DIR environment variables
  from Makefile.environment.

* Overrides previously set environment variables (warns if this occurs)