### PR TITLE
Add axi interface wrapper 

### DIFF
--- a/cl_manycore/build/encrypt.tcl
+++ b/cl_manycore/build/encrypt.tcl
@@ -36,6 +36,7 @@ if {[llength [glob -nocomplain -dir $TARGET_DIR *]] != 0} {
 
 # List your design files below. Include any .inc files, but do NOT include
 # AWS source files.
+file copy -force $COMMON_DIR/f1_bladerunner_ports.inc                         $TARGET_DIR
 file copy -force $COMMON_DIR/bsg_axi_bus_pkg.vh                               $TARGET_DIR
 file copy -force $COMMON_DIR/axil_to_mcl.vh                                   $TARGET_DIR
 file copy -force $COMMON_DIR/axil_to_mcl.v                                    $TARGET_DIR
@@ -43,10 +44,12 @@ file copy -force $COMMON_DIR/s_axil_mcl_adapter.v                             $T
 file copy -force $COMMON_DIR/axil_to_mem.sv                                   $TARGET_DIR
 file copy -force $COMMON_DIR/bsg_bladerunner_rom_pkg.vh                       $TARGET_DIR
 file copy -force $COMMON_DIR/bsg_bladerunner_rom.v                            $TARGET_DIR
+file copy -force $COMMON_DIR/axi_mux.v                                        $TARGET_DIR
 
 file copy -force $CL_DIR/hardware/cl_manycore_pkg.v                           $TARGET_DIR
 file copy -force $CL_DIR/hardware/cl_manycore_defines.vh                      $TARGET_DIR
 file copy -force $CL_DIR/hardware/cl_id_defines.vh                            $TARGET_DIR
+file copy -force $CL_DIR/hardware/cl_target_defines.vh                        $TARGET_DIR
 file copy -force $CL_DIR/hardware/cl_manycore.sv                              $TARGET_DIR
 file copy -force $CL_DIR/hardware/bsg_bladerunner_configuration.v             $TARGET_DIR
 

--- a/cl_manycore/build/encrypt.tcl
+++ b/cl_manycore/build/encrypt.tcl
@@ -49,7 +49,6 @@ file copy -force $COMMON_DIR/axi_mux.v                                        $T
 file copy -force $CL_DIR/hardware/cl_manycore_pkg.v                           $TARGET_DIR
 file copy -force $CL_DIR/hardware/cl_manycore_defines.vh                      $TARGET_DIR
 file copy -force $CL_DIR/hardware/cl_id_defines.vh                            $TARGET_DIR
-file copy -force $CL_DIR/hardware/cl_target_defines.vh                        $TARGET_DIR
 file copy -force $CL_DIR/hardware/cl_manycore.sv                              $TARGET_DIR
 file copy -force $CL_DIR/hardware/bsg_bladerunner_configuration.v             $TARGET_DIR
 

--- a/cl_manycore/hardware/cl_manycore.sv
+++ b/cl_manycore/hardware/cl_manycore.sv
@@ -14,7 +14,6 @@ module cl_manycore
 // For some silly reason, you need to leave this up here...
 logic rst_main_n_sync;
 
-`include "cl_target_defines.vh"
 `include "cl_id_defines.vh"
 `include "cl_manycore_defines.vh"
 

--- a/cl_manycore/hardware/cl_manycore.sv
+++ b/cl_manycore/hardware/cl_manycore.sv
@@ -2,11 +2,10 @@
  *  cl_manycore.v
  */
 
-`include "bsg_bladerunner_rom_pkg.vh"
+`include "cl_manycore_pkg.v"
+import cl_manycore_pkg::*;
 
 module cl_manycore
-  import cl_manycore_pkg::*;
-  import bsg_bladerunner_rom_pkg::*;
   (
     `include "cl_ports.vh"
   );
@@ -15,8 +14,7 @@ module cl_manycore
 // For some silly reason, you need to leave this up here...
 logic rst_main_n_sync;
 
-`include "bsg_defines.v"
-`include "bsg_manycore_packet.vh"
+`include "cl_target_defines.vh"
 `include "cl_id_defines.vh"
 `include "cl_manycore_defines.vh"
 
@@ -99,541 +97,29 @@ assign pre_cl_sh_status_vled[15:0] = vled_q[15:0];
 assign cl_sh_status0[31:0] = 32'h0;
 assign cl_sh_status1[31:0] = 32'h0;
 
-//-------------------------------------------------
-// Post-Pipeline-Register OCL AXI-L Signals
-//-------------------------------------------------
-logic        m_axil_ocl_awvalid;
-logic [31:0] m_axil_ocl_awaddr;
-logic        m_axil_ocl_awready;
 
-logic        m_axil_ocl_wvalid;
-logic [31:0] m_axil_ocl_wdata;
-logic [ 3:0] m_axil_ocl_wstrb;
-logic        m_axil_ocl_wready;
+// -------------------------------------------------------
+// HammerBlader Manycore wrapper
+// -------------------------------------------------------
+`ifdef BSG_TARGET_F1
+`include "f1_bladerunner_ports.inc"
+`else
+`include "vcu128_bladerunner_ports.inc"
+`endif
 
-logic        m_axil_ocl_bvalid;
-logic [ 1:0] m_axil_ocl_bresp;
-logic        m_axil_ocl_bready;
-
-logic        m_axil_ocl_arvalid;
-logic [31:0] m_axil_ocl_araddr;
-logic        m_axil_ocl_arready;
-
-logic        m_axil_ocl_rvalid;
-logic [31:0] m_axil_ocl_rdata;
-logic [ 1:0] m_axil_ocl_rresp;
-logic        m_axil_ocl_rready;
-
-//--------------------------------------------
-// AXI4 signals for the Manycore
-//---------------------------------------------
-logic [5:0] m_axi4_manycore_awid;
-logic [63:0] m_axi4_manycore_awaddr;
-logic [7:0] m_axi4_manycore_awlen;
-logic [2:0] m_axi4_manycore_awsize;
-logic [1:0] m_axi4_manycore_awburst;
-logic [0:0] m_axi4_manycore_awlock;
-logic [3:0] m_axi4_manycore_awcache;
-logic [2:0] m_axi4_manycore_awprot;
-logic [3:0] m_axi4_manycore_awregion;
-logic [3:0] m_axi4_manycore_awqos;
-logic m_axi4_manycore_awvalid;
-logic m_axi4_manycore_awready;
-
-logic [511:0] m_axi4_manycore_wdata;
-logic [63:0] m_axi4_manycore_wstrb;
-logic m_axi4_manycore_wlast;
-logic m_axi4_manycore_wvalid;
-logic m_axi4_manycore_wready;
-
-logic [5:0] m_axi4_manycore_bid;
-logic [1:0] m_axi4_manycore_bresp;
-logic m_axi4_manycore_bvalid;
-logic m_axi4_manycore_bready;
-
-logic [5:0] m_axi4_manycore_arid;
-logic [63:0] m_axi4_manycore_araddr;
-logic [7:0] m_axi4_manycore_arlen;
-logic [2:0] m_axi4_manycore_arsize;
-logic [1:0] m_axi4_manycore_arburst;
-logic [0:0] m_axi4_manycore_arlock;
-logic [3:0] m_axi4_manycore_arcache;
-logic [2:0] m_axi4_manycore_arprot;
-logic [3:0] m_axi4_manycore_arregion;
-logic [3:0] m_axi4_manycore_arqos;
-logic m_axi4_manycore_arvalid;
-logic m_axi4_manycore_arready;
-
-logic [5:0] m_axi4_manycore_rid;
-logic [511:0] m_axi4_manycore_rdata;
-logic [1:0] m_axi4_manycore_rresp;
-logic m_axi4_manycore_rlast;
-logic m_axi4_manycore_rvalid;
-logic m_axi4_manycore_rready;
-
-//--------------------------------------------
-// Concatenated Signals
-//---------------------------------------------
-logic [`axi4_to_sh_ddr_num*6-1:0] m_axi4_concat_awid;
-logic [`axi4_to_sh_ddr_num*64-1:0] m_axi4_concat_awaddr;
-logic [`axi4_to_sh_ddr_num*8-1:0] m_axi4_concat_awlen;
-logic [`axi4_to_sh_ddr_num*3-1:0] m_axi4_concat_awsize;
-logic [`axi4_to_sh_ddr_num*2-1:0] m_axi4_concat_awburst;
-logic [`axi4_to_sh_ddr_num*1-1:0] m_axi4_concat_awlock;
-logic [`axi4_to_sh_ddr_num*4-1:0] m_axi4_concat_awcache;
-logic [`axi4_to_sh_ddr_num*3-1:0] m_axi4_concat_awprot;
-logic [`axi4_to_sh_ddr_num*3-1:0] m_axi4_concat_awregion;
-logic [`axi4_to_sh_ddr_num*4-1:0] m_axi4_concat_awqos;
-logic [`axi4_to_sh_ddr_num*1-1:0] m_axi4_concat_awvalid;
-logic [`axi4_to_sh_ddr_num*1-1:0] m_axi4_concat_awready;
-
-logic [`axi4_to_sh_ddr_num*512-1:0] m_axi4_concat_wdata;
-logic [`axi4_to_sh_ddr_num*64-1:0] m_axi4_concat_wstrb;
-logic [`axi4_to_sh_ddr_num*1-1:0] m_axi4_concat_wlast;
-logic [`axi4_to_sh_ddr_num*1-1:0] m_axi4_concat_wvalid;
-logic [`axi4_to_sh_ddr_num*1-1:0] m_axi4_concat_wready;
-
-logic [`axi4_to_sh_ddr_num*6-1:0] m_axi4_concat_bid;
-logic [`axi4_to_sh_ddr_num*2-1:0] m_axi4_concat_bresp;
-logic [`axi4_to_sh_ddr_num*1-1:0] m_axi4_concat_bvalid;
-logic [`axi4_to_sh_ddr_num*1-1:0] m_axi4_concat_bready;
-
-logic [`axi4_to_sh_ddr_num*6-1:0] m_axi4_concat_arid;
-logic [`axi4_to_sh_ddr_num*64-1:0] m_axi4_concat_araddr;
-logic [`axi4_to_sh_ddr_num*8-1:0] m_axi4_concat_arlen;
-logic [`axi4_to_sh_ddr_num*3-1:0] m_axi4_concat_arsize;
-logic [`axi4_to_sh_ddr_num*2-1:0] m_axi4_concat_arburst;
-logic [`axi4_to_sh_ddr_num*1-1:0] m_axi4_concat_arlock;
-logic [`axi4_to_sh_ddr_num*4-1:0] m_axi4_concat_arcache;
-logic [`axi4_to_sh_ddr_num*3-1:0] m_axi4_concat_arprot;
-logic [`axi4_to_sh_ddr_num*3-1:0] m_axi4_concat_arregion;
-logic [`axi4_to_sh_ddr_num*4-1:0] m_axi4_concat_arqos;
-logic [`axi4_to_sh_ddr_num*1-1:0] m_axi4_concat_arvalid;
-logic [`axi4_to_sh_ddr_num*1-1:0] m_axi4_concat_arready;
-
-logic [`axi4_to_sh_ddr_num*6-1:0] m_axi4_concat_rid;
-logic [`axi4_to_sh_ddr_num*512-1:0] m_axi4_concat_rdata;
-logic [`axi4_to_sh_ddr_num*2-1:0] m_axi4_concat_rresp;
-logic [`axi4_to_sh_ddr_num*1-1:0] m_axi4_concat_rlast;
-logic [`axi4_to_sh_ddr_num*1-1:0] m_axi4_concat_rvalid;
-logic [`axi4_to_sh_ddr_num*1-1:0] m_axi4_concat_rready;
-
-//--------------------------------------------
-// AXI4 DMA/Manycore System
-//---------------------------------------------
-
-//--------------------------------------------
-// Concatenate Manycore and DMA Signals for the Crossbar
-//---------------------------------------------
-assign {m_axi4_manycore_rid, cl_sh_dma_pcis_rid} = m_axi4_concat_rid;
-assign {m_axi4_manycore_rdata, cl_sh_dma_pcis_rdata} = m_axi4_concat_rdata;
-assign {m_axi4_manycore_rresp, cl_sh_dma_pcis_rresp} = m_axi4_concat_rresp;
-assign {m_axi4_manycore_rlast, cl_sh_dma_pcis_rlast} = m_axi4_concat_rlast;
-assign {m_axi4_manycore_rvalid, cl_sh_dma_pcis_rvalid} = m_axi4_concat_rvalid;
-assign m_axi4_concat_rready = {m_axi4_manycore_rready, sh_cl_dma_pcis_rready};
-
-assign m_axi4_concat_awid = {m_axi4_manycore_awid, sh_cl_dma_pcis_awid};
-assign m_axi4_concat_awaddr = {m_axi4_manycore_awaddr, sh_cl_dma_pcis_awaddr};
-assign m_axi4_concat_awlen = {m_axi4_manycore_awlen, sh_cl_dma_pcis_awlen};
-assign m_axi4_concat_awsize = {m_axi4_manycore_awsize, sh_cl_dma_pcis_awsize};
-assign m_axi4_concat_awburst = {m_axi4_manycore_awburst, 2'b01};
-assign m_axi4_concat_awlock = {m_axi4_manycore_awlock, 2'b00};
-assign m_axi4_concat_awcache = {m_axi4_manycore_awcache, 4'b0000};
-assign m_axi4_concat_awprot = {m_axi4_manycore_awprot, 3'b000};
-assign m_axi4_concat_awregion = {m_axi4_manycore_awregion, 4'b0000};
-assign m_axi4_concat_awqos = {m_axi4_manycore_awqos, 4'b0000};
-assign m_axi4_concat_awvalid = {m_axi4_manycore_awvalid, sh_cl_dma_pcis_awvalid};
-assign {m_axi4_manycore_awready, cl_sh_dma_pcis_awready} = m_axi4_concat_awready;
-
-assign m_axi4_concat_wdata = {m_axi4_manycore_wdata, sh_cl_dma_pcis_wdata};
-assign m_axi4_concat_wstrb = {m_axi4_manycore_wstrb, sh_cl_dma_pcis_wstrb};
-assign m_axi4_concat_wlast = {m_axi4_manycore_wlast, sh_cl_dma_pcis_wlast};
-assign m_axi4_concat_wvalid = {m_axi4_manycore_wvalid, sh_cl_dma_pcis_wvalid};
-assign {m_axi4_manycore_wready, cl_sh_dma_pcis_wready} = m_axi4_concat_wready;
-
-assign {m_axi4_manycore_bid, cl_sh_dma_pcis_bid} = m_axi4_concat_bid;
-assign {m_axi4_manycore_bresp, cl_sh_dma_pcis_bresp} = m_axi4_concat_bresp;
-assign {m_axi4_manycore_bvalid, cl_sh_dma_pcis_bvalid} = m_axi4_concat_bvalid;
-assign m_axi4_concat_bready = {m_axi4_manycore_bready, sh_cl_dma_pcis_bready};
-
-assign m_axi4_concat_arid = {m_axi4_manycore_arid, sh_cl_dma_pcis_arid};
-assign m_axi4_concat_araddr = {m_axi4_manycore_araddr, sh_cl_dma_pcis_araddr};
-assign m_axi4_concat_arlen = {m_axi4_manycore_arlen, sh_cl_dma_pcis_arlen};
-assign m_axi4_concat_arsize = {m_axi4_manycore_arsize, sh_cl_dma_pcis_arsize};
-assign m_axi4_concat_arburst = {m_axi4_manycore_arburst, 2'b01};
-assign m_axi4_concat_arlock = {m_axi4_manycore_arlock, 2'b00};
-assign m_axi4_concat_arcache = {m_axi4_manycore_arcache, 4'b0000};
-assign m_axi4_concat_arprot = {m_axi4_manycore_arprot, 3'b000};
-assign m_axi4_concat_arregion = {m_axi4_manycore_arregion, 4'b0000};
-assign m_axi4_concat_arqos = {m_axi4_manycore_arqos, 4'b0000};
-assign m_axi4_concat_arvalid = {m_axi4_manycore_arvalid, sh_cl_dma_pcis_arvalid};
-assign {m_axi4_manycore_arready, cl_sh_dma_pcis_arready} = m_axi4_concat_arready;
-
-axi_crossbar_v2_1_18_axi_crossbar #(
-  .C_FAMILY                   ("virtexuplus"       ),
-  .C_NUM_SLAVE_SLOTS          (2                   ),
-  .C_NUM_MASTER_SLOTS         (1                   ),
-  .C_AXI_ID_WIDTH             (6                   ),
-  .C_AXI_ADDR_WIDTH           (64                  ),
-  .C_AXI_DATA_WIDTH           (512                 ),
-  .C_AXI_PROTOCOL             (0                   ), // 0 is AXI4 Full
-  .C_NUM_ADDR_RANGES          (1                   ),
-  .C_M_AXI_BASE_ADDR          (128'H00000000000000000000000000000000),
-  .C_M_AXI_ADDR_WIDTH         (64'H0000004000000040),
-  .C_S_AXI_BASE_ID            (64'H0000000000000000),
-  .C_S_AXI_THREAD_ID_WIDTH    (64'H0000000500000005),
-  .C_AXI_SUPPORTS_USER_SIGNALS(0                   ),
-  .C_AXI_AWUSER_WIDTH         (1                   ),
-  .C_AXI_ARUSER_WIDTH         (1                   ),
-  .C_AXI_WUSER_WIDTH          (1                   ),
-  .C_AXI_RUSER_WIDTH          (1                   ),
-  .C_AXI_BUSER_WIDTH          (1                   ),
-  .C_M_AXI_WRITE_CONNECTIVITY (32'H00000003        ),
-  .C_M_AXI_READ_CONNECTIVITY  (32'H00000003        ),
-  .C_R_REGISTER               (0                   ),
-  .C_S_AXI_SINGLE_THREAD      (64'H0000000000000000),
-  .C_S_AXI_WRITE_ACCEPTANCE   (64'H0000000200000002),
-  .C_S_AXI_READ_ACCEPTANCE    (64'H0000000200000002),
-  .C_M_AXI_WRITE_ISSUING      (32'H00000004        ),
-  .C_M_AXI_READ_ISSUING       (32'H00000004        ),
-  .C_S_AXI_ARB_PRIORITY       (64'H0000000000000000),
-  .C_M_AXI_SECURE             (32'H00000000        ),
-  .C_CONNECTIVITY_MODE        (0                   )
-) xbar (
-  .aclk          (clk_main_a0    ),
-  .aresetn       (rst_main_n_sync),
-  .s_axi_awid    (m_axi4_concat_awid   ),
-  .s_axi_awaddr  (m_axi4_concat_awaddr ),
-  .s_axi_awlen   (m_axi4_concat_awlen  ),
-  .s_axi_awsize  (m_axi4_concat_awsize ),
-  .s_axi_awburst (m_axi4_concat_awburst),
-  .s_axi_awlock  (m_axi4_concat_awlock ),
-  .s_axi_awcache (m_axi4_concat_awcache),
-  .s_axi_awprot  (m_axi4_concat_awprot ),
-  .s_axi_awqos   (m_axi4_concat_awqos  ),
-  .s_axi_awuser  (2'b0),
-  .s_axi_awvalid (m_axi4_concat_awvalid),
-  .s_axi_awready (m_axi4_concat_awready),
-  .s_axi_wid     (12'H0         ),
-  .s_axi_wdata   (m_axi4_concat_wdata  ),
-  .s_axi_wstrb   (m_axi4_concat_wstrb  ),
-  .s_axi_wlast   (m_axi4_concat_wlast  ),
-  .s_axi_wuser   (2'H0          ),
-  .s_axi_wvalid  (m_axi4_concat_wvalid ),
-  .s_axi_wready  (m_axi4_concat_wready ),
-  .s_axi_bid     (m_axi4_concat_bid    ),
-  .s_axi_bresp   (m_axi4_concat_bresp  ),
-  .s_axi_buser   (              ),
-  .s_axi_bvalid  (m_axi4_concat_bvalid ),
-  .s_axi_bready  (m_axi4_concat_bready ),
-  .s_axi_arid    (m_axi4_concat_arid   ),
-  .s_axi_araddr  (m_axi4_concat_araddr ),
-  .s_axi_arlen   (m_axi4_concat_arlen  ),
-  .s_axi_arsize  (m_axi4_concat_arsize ),
-  .s_axi_arburst (m_axi4_concat_arburst),
-  .s_axi_arlock  (m_axi4_concat_arlock ),
-  .s_axi_arcache (m_axi4_concat_arcache),
-  .s_axi_arprot  (m_axi4_concat_arprot ),
-  .s_axi_arqos   (m_axi4_concat_arqos  ),
-  .s_axi_aruser  (2'H0          ),
-  .s_axi_arvalid (m_axi4_concat_arvalid),
-  .s_axi_arready (m_axi4_concat_arready),
-  .s_axi_rid     (m_axi4_concat_rid    ),
-  .s_axi_rdata   (m_axi4_concat_rdata  ),
-  .s_axi_rresp   (m_axi4_concat_rresp  ),
-  .s_axi_rlast   (m_axi4_concat_rlast  ),
-  .s_axi_ruser   (              ),
-  .s_axi_rvalid  (m_axi4_concat_rvalid ),
-  .s_axi_rready  (m_axi4_concat_rready ),
-  .m_axi_awid    (cl_sh_ddr_awid[5:0]  ),
-  .m_axi_awaddr  (cl_sh_ddr_awaddr   ),
-  .m_axi_awlen   (cl_sh_ddr_awlen    ),
-  .m_axi_awsize  (cl_sh_ddr_awsize   ),
-  .m_axi_awburst (cl_sh_ddr_awburst  ),
-  .m_axi_awlock  (                   ),
-  .m_axi_awcache (                   ),
-  .m_axi_awprot  (                   ),
-  .m_axi_awregion(                   ),
-  .m_axi_awqos   (                   ),
-  .m_axi_awuser  (                   ),
-  .m_axi_awvalid (cl_sh_ddr_awvalid  ),
-  .m_axi_awready (sh_cl_ddr_awready  ),
-  .m_axi_wid     (cl_sh_ddr_wid[5:0] ),
-  .m_axi_wdata   (cl_sh_ddr_wdata    ),
-  .m_axi_wstrb   (cl_sh_ddr_wstrb    ),
-  .m_axi_wlast   (cl_sh_ddr_wlast    ),
-  .m_axi_wuser   (                   ),
-  .m_axi_wvalid  (cl_sh_ddr_wvalid   ),
-  .m_axi_wready  (sh_cl_ddr_wready   ),
-  .m_axi_bid     (sh_cl_ddr_bid[5:0] ),
-  .m_axi_bresp   (sh_cl_ddr_bresp    ),
-  .m_axi_buser   (                   ),
-  .m_axi_bvalid  (sh_cl_ddr_bvalid   ),
-  .m_axi_bready  (cl_sh_ddr_bready   ),
-  .m_axi_arid    (cl_sh_ddr_arid[5:0]),
-  .m_axi_araddr  (cl_sh_ddr_araddr   ),
-  .m_axi_arlen   (cl_sh_ddr_arlen    ),
-  .m_axi_arsize  (cl_sh_ddr_arsize   ),
-  .m_axi_arburst (cl_sh_ddr_arburst  ),
-  .m_axi_arlock  (                   ),
-  .m_axi_arcache (                   ),
-  .m_axi_arprot  (                   ),
-  .m_axi_arregion(                   ),
-  .m_axi_arqos   (                   ),
-  .m_axi_aruser  (                   ),
-  .m_axi_arvalid (cl_sh_ddr_arvalid  ),
-  .m_axi_arready (sh_cl_ddr_arready  ),
-  .m_axi_rid     (sh_cl_ddr_rid[5:0] ),
-  .m_axi_rdata   (sh_cl_ddr_rdata    ),
-  .m_axi_rresp   (sh_cl_ddr_rresp    ),
-  .m_axi_rlast   (sh_cl_ddr_rlast    ),
-  .m_axi_ruser   (1'H0               ),
-  .m_axi_rvalid  (sh_cl_ddr_rvalid   ),
-  .m_axi_rready  (cl_sh_ddr_rready   ));
-
-//--------------------------------------------
-// AXI-Lite OCL System
-//---------------------------------------------
-
-// Tied to 0, for now:
-//assign m_axil_ocl_awready = 1'b0;
-//assign m_axil_ocl_wready = 1'b0;
-//assign m_axil_ocl_bvalid = 1'b0;
-//assign m_axil_ocl_bresp = 2'b00;
-//assign m_axil_ocl_arready = 1'b0;
-
-// Read data/response
-//assign m_axil_ocl_rvalid = 1'b0;
-//assign m_axil_ocl_rresp = 2'b00;
-
-axi_register_slice_light AXIL_OCL_REG_SLC (
-   .aclk          (clk_main_a0),
-   .aresetn       (rst_main_n_sync),
-   .s_axi_awaddr  (sh_ocl_awaddr),
-   .s_axi_awprot  (3'h0),
-   .s_axi_awvalid (sh_ocl_awvalid),
-   .s_axi_awready (ocl_sh_awready),
-   .s_axi_wdata   (sh_ocl_wdata),
-   .s_axi_wstrb   (sh_ocl_wstrb),
-   .s_axi_wvalid  (sh_ocl_wvalid),
-   .s_axi_wready  (ocl_sh_wready),
-   .s_axi_bresp   (ocl_sh_bresp),
-   .s_axi_bvalid  (ocl_sh_bvalid),
-   .s_axi_bready  (sh_ocl_bready),
-   .s_axi_araddr  (sh_ocl_araddr),
-   .s_axi_arvalid (sh_ocl_arvalid),
-   .s_axi_arready (ocl_sh_arready),
-   .s_axi_rdata   (ocl_sh_rdata),
-   .s_axi_rresp   (ocl_sh_rresp),
-   .s_axi_rvalid  (ocl_sh_rvalid),
-   .s_axi_rready  (sh_ocl_rready),
-   .m_axi_awaddr  (m_axil_ocl_awaddr),
-   .m_axi_awprot  (),
-   .m_axi_awvalid (m_axil_ocl_awvalid),
-   .m_axi_awready (m_axil_ocl_awready),
-   .m_axi_wdata   (m_axil_ocl_wdata),
-   .m_axi_wstrb   (m_axil_ocl_wstrb),
-   .m_axi_wvalid  (m_axil_ocl_wvalid),
-   .m_axi_wready  (m_axil_ocl_wready),
-   .m_axi_bresp   (m_axil_ocl_bresp),
-   .m_axi_bvalid  (m_axil_ocl_bvalid),
-   .m_axi_bready  (m_axil_ocl_bready),
-   .m_axi_araddr  (m_axil_ocl_araddr),
-   .m_axi_arvalid (m_axil_ocl_arvalid),
-   .m_axi_arready (m_axil_ocl_arready),
-   .m_axi_rdata   (m_axil_ocl_rdata),
-   .m_axi_rresp   (m_axil_ocl_rresp),
-   .m_axi_rvalid  (m_axil_ocl_rvalid),
-   .m_axi_rready  (m_axil_ocl_rready)
-  );
-
-// manycore wrapper
-`declare_bsg_manycore_link_sif_s(addr_width_p, data_width_p, x_cord_width_p, y_cord_width_p, load_id_width_p);
-
-bsg_manycore_link_sif_s [num_cache_p-1:0] cache_link_sif_li;
-bsg_manycore_link_sif_s [num_cache_p-1:0] cache_link_sif_lo;
-
-logic [num_cache_p-1:0][x_cord_width_p-1:0] cache_x_lo;
-logic [num_cache_p-1:0][y_cord_width_p-1:0] cache_y_lo;
-
-bsg_manycore_link_sif_s loader_link_sif_li;
-bsg_manycore_link_sif_s loader_link_sif_lo;
-
-bsg_manycore_link_sif_s rom_link_sif_li;
-bsg_manycore_link_sif_s rom_link_sif_lo;
-
-bsg_manycore_wrapper #(
-  .addr_width_p(addr_width_p)
-  ,.data_width_p(data_width_p)
-  ,.num_tiles_x_p(num_tiles_x_p)
-  ,.num_tiles_y_p(num_tiles_y_p)
-  ,.dmem_size_p(dmem_size_p)
-  ,.icache_entries_p(icache_entries_p)
-  ,.icache_tag_width_p(icache_tag_width_p)
-  ,.epa_byte_addr_width_p(epa_byte_addr_width_p)
-  ,.dram_ch_addr_width_p(dram_ch_addr_width_p)
-  ,.load_id_width_p(load_id_width_p)
-  ,.num_cache_p(num_cache_p)
-) manycore_wrapper (
-  .clk_i(clk_main_a0)
-  ,.reset_i(~rst_main_n_sync)
-
-  ,.cache_link_sif_i(cache_link_sif_li)
-  ,.cache_link_sif_o(cache_link_sif_lo)
-
-  ,.cache_x_o(cache_x_lo)
-  ,.cache_y_o(cache_y_lo)
-
-  ,.loader_link_sif_i(loader_link_sif_li)
-  ,.loader_link_sif_o(loader_link_sif_lo)
-
-  ,.rom_link_sif_i(rom_link_sif_li)
-  ,.rom_link_sif_o(rom_link_sif_lo)
-);
-
-
-// cache_wrapper
-//
-bsg_cache_wrapper_axi #(
-  .num_cache_p(num_cache_p)
-  ,.data_width_p(data_width_p)
-  ,.addr_width_p(addr_width_p)
-  ,.block_size_in_words_p(block_size_in_words_p)
-  ,.sets_p(sets_p)
-  ,.ways_p(ways_p)
-
-  ,.axi_id_width_p(axi_id_width_p)
-  ,.axi_addr_width_p(axi_addr_width_p)
-  ,.axi_data_width_p(axi_data_width_p)
-  ,.axi_burst_len_p(axi_burst_len_p)
-
-  ,.x_cord_width_p(x_cord_width_p)
-  ,.y_cord_width_p(y_cord_width_p)
-  ,.load_id_width_p(load_id_width_p)
-) cache_wrapper (
-  .clk_i(clk_main_a0)
-  ,.reset_i(~rst_main_n_sync)
-
-  ,.my_x_i(cache_x_lo)
-  ,.my_y_i(cache_y_lo)
-
-  ,.link_sif_i(cache_link_sif_lo)
-  ,.link_sif_o(cache_link_sif_li)
-
-  ,.axi_awid_o    (m_axi4_manycore_awid)
-  ,.axi_awaddr_o  (m_axi4_manycore_awaddr)
-  ,.axi_awlen_o   (m_axi4_manycore_awlen)
-  ,.axi_awsize_o  (m_axi4_manycore_awsize)
-  ,.axi_awburst_o (m_axi4_manycore_awburst)
-  ,.axi_awcache_o (m_axi4_manycore_awcache)
-  ,.axi_awprot_o  (m_axi4_manycore_awprot)
-  ,.axi_awlock_o  (m_axi4_manycore_awlock)
-  ,.axi_awvalid_o (m_axi4_manycore_awvalid)
-  ,.axi_awready_i (m_axi4_manycore_awready)
-
-  ,.axi_wdata_o   (m_axi4_manycore_wdata)
-  ,.axi_wstrb_o   (m_axi4_manycore_wstrb)
-  ,.axi_wlast_o   (m_axi4_manycore_wlast)
-  ,.axi_wvalid_o  (m_axi4_manycore_wvalid)
-  ,.axi_wready_i  (m_axi4_manycore_wready)
-
-  ,.axi_bid_i     (m_axi4_manycore_bid)
-  ,.axi_bresp_i   (m_axi4_manycore_bresp)
-  ,.axi_bvalid_i  (m_axi4_manycore_bvalid)
-  ,.axi_bready_o  (m_axi4_manycore_bready)
-
-  ,.axi_arid_o    (m_axi4_manycore_arid)
-  ,.axi_araddr_o  (m_axi4_manycore_araddr)
-  ,.axi_arlen_o   (m_axi4_manycore_arlen)
-  ,.axi_arsize_o  (m_axi4_manycore_arsize)
-  ,.axi_arburst_o (m_axi4_manycore_arburst)
-  ,.axi_arcache_o (m_axi4_manycore_arcache)
-  ,.axi_arprot_o  (m_axi4_manycore_arprot)
-  ,.axi_arlock_o  (m_axi4_manycore_arlock)
-  ,.axi_arvalid_o (m_axi4_manycore_arvalid)
-  ,.axi_arready_i (m_axi4_manycore_arready)
-
-  ,.axi_rid_i     (m_axi4_manycore_rid)
-  ,.axi_rdata_i   (m_axi4_manycore_rdata)
-  ,.axi_rresp_i   (m_axi4_manycore_rresp)
-  ,.axi_rlast_i   (m_axi4_manycore_rlast)
-  ,.axi_rvalid_i  (m_axi4_manycore_rvalid)
-  ,.axi_rready_o  (m_axi4_manycore_rready)
-);
-
-assign m_axi4_manycore_awregion = 4'b0;
-assign m_axi4_manycore_awqos = 4'b0;
-
-assign m_axi4_manycore_arregion = 4'b0;
-assign m_axi4_manycore_arqos = 4'b0;
-
-
-// bladerunner configuration rom
-
-logic [x_cord_width_p-1:0] rom_x_cord_lp = '0;
-logic [y_cord_width_p-1:0] rom_y_cord_lp = '0;
-
-bsg_bladerunner_rom #(
-  .rom_width_p    (rom_width_p)
-  ,.rom_els_p      (rom_els_p)
-  ,.x_cord_width_p (x_cord_width_p)
-  ,.y_cord_width_p (y_cord_width_p)
-  ,.addr_width_p   (addr_width_p)
-  ,.data_width_p   (data_width_p)
-  ,.load_id_width_p(load_id_width_p)
-) bladerunner_rom (
-  .clk_i     (clk_main_a0),
-  .reset_i   (~rst_main_n_sync),
-  .my_x_i    (rom_x_cord_lp),
-  .my_y_i    (rom_y_cord_lp),
-  .link_sif_i(rom_link_sif_lo),
-  .link_sif_o(rom_link_sif_li)
-);
-
-
-// manycore link
-
-logic [x_cord_width_p-1:0] mcl_x_cord_lp = x_cord_width_p'(num_tiles_x_p-1);
-logic [y_cord_width_p-1:0] mcl_y_cord_lp = '0;
-
-axil_to_mcl #(
-  .num_mcl_p        (1                )
-  ,.num_tiles_x_p    (num_tiles_x_p    )
-  ,.num_tiles_y_p    (num_tiles_y_p    )
-  ,.addr_width_p     (addr_width_p     )
-  ,.data_width_p     (data_width_p     )
-  ,.x_cord_width_p   (x_cord_width_p   )
-  ,.y_cord_width_p   (y_cord_width_p   )
-  ,.load_id_width_p  (load_id_width_p  )
-  ,.max_out_credits_p(max_out_credits_p)
-) axil_to_mcl_inst (
-  .clk_i             (clk_main_a0       )
-  ,.reset_i           (~rst_main_n_sync  )
-
-  // axil slave interface
-  ,.s_axil_mcl_awvalid(m_axil_ocl_awvalid)
-  ,.s_axil_mcl_awaddr (m_axil_ocl_awaddr )
-  ,.s_axil_mcl_awready(m_axil_ocl_awready)
-  ,.s_axil_mcl_wvalid (m_axil_ocl_wvalid )
-  ,.s_axil_mcl_wdata  (m_axil_ocl_wdata  )
-  ,.s_axil_mcl_wstrb  (m_axil_ocl_wstrb  )
-  ,.s_axil_mcl_wready (m_axil_ocl_wready )
-  ,.s_axil_mcl_bresp  (m_axil_ocl_bresp  )
-  ,.s_axil_mcl_bvalid (m_axil_ocl_bvalid )
-  ,.s_axil_mcl_bready (m_axil_ocl_bready )
-  ,.s_axil_mcl_araddr (m_axil_ocl_araddr )
-  ,.s_axil_mcl_arvalid(m_axil_ocl_arvalid)
-  ,.s_axil_mcl_arready(m_axil_ocl_arready)
-  ,.s_axil_mcl_rdata  (m_axil_ocl_rdata  )
-  ,.s_axil_mcl_rresp  (m_axil_ocl_rresp  )
-  ,.s_axil_mcl_rvalid (m_axil_ocl_rvalid )
-  ,.s_axil_mcl_rready (m_axil_ocl_rready )
-
-  // manycore link
-  ,.link_sif_i        (loader_link_sif_lo)
-  ,.link_sif_o        (loader_link_sif_li)
-  ,.my_x_i            (mcl_x_cord_lp     )
-  ,.my_y_i            (mcl_y_cord_lp     )
+hb_mc_wrapper #(
+  .axi_id_width_p  (axi_id_width_p  ),
+  .axi_addr_width_p(axi_addr_width_p),
+  .axi_data_width_p(axi_data_width_p)
+) hb_mc_inst (
+  .clk_i           (clk_i            ),
+  .resetn_i        (resetn_i         ),
+  .s_axil_ocl_bus_i(s_axil_ocl_li_cast),
+  .s_axil_ocl_bus_o(s_axil_ocl_lo_cast),
+  .s_axi_pcis_bus_i(s_axi_pcis_li_cast),
+  .s_axi_pcis_bus_o(s_axi_pcis_lo_cast),
+  .m_axi_ddr_bus_o (m_axi_ddr_lo_cast ),
+  .m_axi_ddr_bus_i (m_axi_ddr_li_cast )
 );
 
 //-----------------------------------------------
@@ -650,27 +136,26 @@ always_ff @(posedge clk_main_a0)
    else
       sh_cl_glcount0_q <= sh_cl_glcount0;
 
-
 // Integrated Logic Analyzers (ILA)
 ila_0 CL_ILA_0 (
                 .clk    (clk_main_a0),
-                .probe0 (m_axil_ocl_awvalid)
-                ,.probe1 (64'(m_axil_ocl_awaddr))
-                ,.probe2 (m_axil_ocl_awready)
+                .probe0 (sh_ocl_awvalid)
+                ,.probe1 (64'(sh_ocl_awaddr))
+                ,.probe2 (ocl_sh_awready)
                 ,.probe3 (m_axil_ocl_arvalid)
-                ,.probe4 (64'(m_axil_ocl_araddr))
-                ,.probe5 (m_axil_ocl_arready)
+                ,.probe4 (64'(sh_ocl_wdata))
+                ,.probe5 (ocl_sh_wready)
                 );
 
- ila_0 CL_ILA_1 (
-                .clk    (clk_main_a0)
-                ,.probe0 (m_axil_ocl_bvalid)
-                ,.probe1 (sh_cl_glcount0_q)
-                ,.probe2 (m_axil_ocl_bready)
-                ,.probe3 (m_axil_ocl_rvalid)
-                ,.probe4 ({32'b0,m_axil_ocl_rdata[31:0]})
-                ,.probe5 (m_axil_ocl_rready)
-                 );
+ila_0 CL_ILA_1 (
+              .clk    (clk_main_a0)
+              ,.probe0 (sh_ocl_arvalid)
+              ,.probe1 (sh_cl_glcount0_q)
+              ,.probe2 (ocl_sh_arready)
+              ,.probe3 (ocl_sh_rvalid)
+              ,.probe4 (64'(s_axil_rdata_lo))
+              ,.probe5 (sh_ocl_rready)
+               );
 
 // Debug Bridge
 cl_debug_bridge CL_DEBUG_BRIDGE (

--- a/cl_manycore/hardware/cl_manycore_defines.vh
+++ b/cl_manycore/hardware/cl_manycore_defines.vh
@@ -13,9 +13,6 @@
 // Uncomment to disable Virtual JTAG
 //`define DISABLE_VJTAG_DEBUG
 
-// Define macros for the manycore hardware
-`define axi4_to_sh_ddr_num 2
-
 
 `endif
 

--- a/cl_manycore/hardware/cl_manycore_defines.vh
+++ b/cl_manycore/hardware/cl_manycore_defines.vh
@@ -13,6 +13,7 @@
 // Uncomment to disable Virtual JTAG
 //`define DISABLE_VJTAG_DEBUG
 
+`define BSG_TARGET_F1
 
 `endif
 

--- a/cl_manycore/hardware/cl_target_defines.vh
+++ b/cl_manycore/hardware/cl_target_defines.vh
@@ -1,0 +1,6 @@
+`ifndef CL_TARGET_DEFINES
+`define CL_TARGET_DEFINES
+
+`define BSG_TARGET_F1
+
+`endif

--- a/cl_manycore/hardware/cl_target_defines.vh
+++ b/cl_manycore/hardware/cl_target_defines.vh
@@ -1,6 +1,0 @@
-`ifndef CL_TARGET_DEFINES
-`define CL_TARGET_DEFINES
-
-`define BSG_TARGET_F1
-
-`endif

--- a/cl_manycore/regression/library/Makefile.tests
+++ b/cl_manycore/regression/library/Makefile.tests
@@ -1,16 +1,16 @@
 REGRESSION_TESTS_TYPE = library
 
-C_REGRESSION_TESTS = test_struct_size 
-C_REGRESSION_TESTS += test_rom 
-C_REGRESSION_TESTS += test_dmem_read_write 
+C_REGRESSION_TESTS = test_struct_size
+C_REGRESSION_TESTS += test_rom
+C_REGRESSION_TESTS += test_dmem_read_write
 C_REGRESSION_TESTS += test_packets
 C_REGRESSION_TESTS += test_dram_packets
 C_REGRESSION_TESTS += test_vcache_simplified
-C_REGRESSION_TESTS += test_vcache_stride 
+C_REGRESSION_TESTS += test_vcache_stride
 C_REGRESSION_TESTS += test_vcache_sequence
 C_REGRESSION_TESTS += test_dram_read_write
 
-CXX_REGRESSION_TESTS = 
+CXX_REGRESSION_TESTS =
 
 REGRESSION_DEFINES = -DBSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
 	-DCL_MANYCORE_DIM_X=$(CL_MANYCORE_DIM_X) \

--- a/cl_manycore/regression/library/Makefile.tests
+++ b/cl_manycore/regression/library/Makefile.tests
@@ -1,16 +1,17 @@
 REGRESSION_TESTS_TYPE = library
 
-C_REGRESSION_TESTS = test_struct_size
-C_REGRESSION_TESTS += test_rom
-C_REGRESSION_TESTS += test_dmem_read_write
+C_REGRESSION_TESTS = test_struct_size 
+C_REGRESSION_TESTS += test_rom 
+C_REGRESSION_TESTS += test_dmem_read_write 
 C_REGRESSION_TESTS += test_packets
 C_REGRESSION_TESTS += test_dram_packets
 C_REGRESSION_TESTS += test_vcache_simplified
-C_REGRESSION_TESTS += test_vcache_stride
+C_REGRESSION_TESTS += test_vcache_stride 
 C_REGRESSION_TESTS += test_vcache_sequence
 C_REGRESSION_TESTS += test_dram_read_write
+C_REGRESSION_TESTS += test_printing
 
-CXX_REGRESSION_TESTS =
+CXX_REGRESSION_TESTS = 
 
 REGRESSION_DEFINES = -DBSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \
 	-DCL_MANYCORE_DIM_X=$(CL_MANYCORE_DIM_X) \

--- a/cl_manycore/testbenches/top.vivado.f
+++ b/cl_manycore/testbenches/top.vivado.f
@@ -54,10 +54,14 @@
 ${CL_DIR}/hardware/cl_manycore_pkg.v
 ${CL_DIR}/hardware/cl_manycore.sv
 ${CL_DIR}/hardware/bsg_bladerunner_configuration.v
-${CL_DIR}/../hdl/axil_to_mcl.v
-${CL_DIR}/../hdl/s_axil_mcl_adapter.v
-${CL_DIR}/../hdl/axil_to_mem.sv
+${CL_DIR}/../hdl/hb_mc_wrapper.v
+${CL_DIR}/../hdl/axi_mux.v
 ${CL_DIR}/../hdl/bsg_bladerunner_rom.v
+# TODO: remove Xilinx dependency
+${CL_DIR}/../hdl/axil_to_mcl.v
+${CL_DIR}/../hdl/axil_to_mem.sv
+${CL_DIR}/../hdl/s_axil_mcl_adapter.v
+
 ${BSG_IP_CORES_DIR}/bsg_noc/bsg_noc_pkg.v
 ${BSG_IP_CORES_DIR}/bsg_noc/bsg_mesh_stitch.v
 ${BSG_IP_CORES_DIR}/bsg_noc/bsg_mesh_router_buffered.v

--- a/hdl/axi_mux.v
+++ b/hdl/axi_mux.v
@@ -1,0 +1,229 @@
+/**
+*  axi_mux.v
+*
+*/
+
+`include "bsg_axi_bus_pkg.vh"
+
+module axi_mux #(
+  parameter slot_num_p = "inv"
+  , parameter id_width_p = "inv"
+  , parameter addr_width_p = "inv"
+  , parameter data_width_p = "inv"
+  , localparam axi_mosi_bus_width_lp = `bsg_axi_mosi_bus_width(1, id_width_p, addr_width_p, data_width_p)
+  , localparam axi_miso_bus_width_lp = `bsg_axi_miso_bus_width(1, id_width_p, addr_width_p, data_width_p)
+) (
+  input                                                         clk_i
+  ,input                                                         reset_i
+  ,input  [           slot_num_p-1:0][axi_mosi_bus_width_lp-1:0] s_axi_mux_i
+  ,output [           slot_num_p-1:0][axi_miso_bus_width_lp-1:0] s_axi_mux_o
+  ,output [axi_mosi_bus_width_lp-1:0]                            m_axi_bus_o
+  ,input  [axi_miso_bus_width_lp-1:0]                            m_axi_bus_i
+);
+
+  `declare_bsg_axi_bus_s(slot_num_p, id_width_p, addr_width_p, data_width_p, bsg_axi_mosi_mux_s, bsg_axi_miso_mux_s);
+  `declare_bsg_axi_bus_s(1, id_width_p, addr_width_p, data_width_p, bsg_axi_mosi_bus_s, bsg_axi_miso_bus_s);
+
+//---------------------------------------------
+// Concatenated Signals
+//---------------------------------------------
+  bsg_axi_mosi_mux_s s_axi_mux_i_cast;
+  bsg_axi_miso_mux_s s_axi_mux_o_cast;
+
+  bsg_axi_mosi_bus_s [slot_num_p-1:0] s_axi_li_cast;
+  bsg_axi_miso_bus_s [slot_num_p-1:0] s_axi_lo_cast;
+
+  assign s_axi_li_cast = s_axi_mux_i;
+  assign s_axi_mux_o   = s_axi_lo_cast;
+
+  for (genvar i=0; i<slot_num_p; i=i+1) begin
+
+    always_comb begin: axi_slave_input
+
+      s_axi_mux_i_cast.awid[i*id_width_p+:id_width_p] = s_axi_li_cast[i].awid;
+      s_axi_mux_i_cast.awaddr[i*addr_width_p+:addr_width_p] = s_axi_li_cast[i].awaddr;
+      s_axi_mux_i_cast.awlen[i*8+:8] = s_axi_li_cast[i].awlen;
+      s_axi_mux_i_cast.awsize[i*3+:3] = s_axi_li_cast[i].awsize;
+      s_axi_mux_i_cast.awburst[i*2+:2] = s_axi_li_cast[i].awburst;
+      s_axi_mux_i_cast.awlock[i] = s_axi_li_cast[i].awlock;
+      s_axi_mux_i_cast.awcache[i*4+:4] = s_axi_li_cast[i].awcache;
+      s_axi_mux_i_cast.awprot[i*3+:3] = s_axi_li_cast[i].awprot;
+      s_axi_mux_i_cast.awqos[i*4+:4] = s_axi_li_cast[i].awqos;
+      s_axi_mux_i_cast.awregion[i*4+:4] = s_axi_li_cast[i].awregion;
+      s_axi_mux_i_cast.awvalid[i] = s_axi_li_cast[i].awvalid;
+
+      s_axi_mux_i_cast.wdata[i*data_width_p+:data_width_p] = s_axi_li_cast[i].wdata;
+      s_axi_mux_i_cast.wstrb[i*(data_width_p/8)+:(data_width_p/8)] = s_axi_li_cast[i].wstrb;
+      s_axi_mux_i_cast.wlast[i] = s_axi_li_cast[i].wlast;
+      s_axi_mux_i_cast.wvalid[i] = s_axi_li_cast[i].wvalid;
+
+      s_axi_mux_i_cast.bready[i] = s_axi_li_cast[i].bready;
+
+      s_axi_mux_i_cast.arid[i*id_width_p+:id_width_p] = s_axi_li_cast[i].arid;
+      s_axi_mux_i_cast.araddr[i*addr_width_p+:addr_width_p] = s_axi_li_cast[i].araddr;
+      s_axi_mux_i_cast.arlen[i*8+:8] = s_axi_li_cast[i].arlen;
+      s_axi_mux_i_cast.arsize[i*3+:3] = s_axi_li_cast[i].arsize;
+      s_axi_mux_i_cast.arburst[i*2+:2] = s_axi_li_cast[i].arburst;
+      s_axi_mux_i_cast.arlock[i] = s_axi_li_cast[i].arlock;
+      s_axi_mux_i_cast.arcache[i*4+:4] = s_axi_li_cast[i].arcache;
+      s_axi_mux_i_cast.arprot[i*3+:3] = s_axi_li_cast[i].arprot;
+      s_axi_mux_i_cast.arqos[i*4+:4] = s_axi_li_cast[i].arqos;
+      s_axi_mux_i_cast.arregion[i*4+:4] = s_axi_li_cast[i].arregion;
+      s_axi_mux_i_cast.arvalid[i] = s_axi_li_cast[i].arvalid;
+
+      s_axi_mux_i_cast.rready[i] = s_axi_li_cast[i].rready;
+      
+    end
+
+    always_comb begin: axi_slave_output
+
+      s_axi_lo_cast[i].awready = s_axi_mux_o_cast.awready[i];
+      s_axi_lo_cast[i].wready = s_axi_mux_o_cast.wready[i];
+
+      s_axi_lo_cast[i].bid = s_axi_mux_o_cast.bid[i*id_width_p+:id_width_p];
+      s_axi_lo_cast[i].bresp = s_axi_mux_o_cast.bresp[i*2+:2];
+      s_axi_lo_cast[i].bvalid = s_axi_mux_o_cast.bvalid[i];
+
+      s_axi_lo_cast[i].arready = s_axi_mux_o_cast.arready[i];
+
+      s_axi_lo_cast[i].rid = s_axi_mux_o_cast.rid[i*id_width_p+:id_width_p];
+      s_axi_lo_cast[i].rdata = s_axi_mux_o_cast.rdata[i*data_width_p+:data_width_p];
+      s_axi_lo_cast[i].rresp = s_axi_mux_o_cast.rresp[i*2+:2];
+      s_axi_lo_cast[i].rlast = s_axi_mux_o_cast.rlast[i];
+      s_axi_lo_cast[i].rvalid = s_axi_mux_o_cast.rvalid[i];
+
+    end
+  end
+
+
+  bsg_axi_mosi_bus_s m_axi_bus_o_cast;
+  bsg_axi_miso_bus_s m_axi_bus_i_cast;
+
+  assign m_axi_bus_o      = m_axi_bus_o_cast;
+  assign m_axi_bus_i_cast = m_axi_bus_i;
+
+  axi_crossbar_v2_1_18_axi_crossbar #(
+    .C_FAMILY                   ("virtexuplus"                        ),
+    .C_NUM_SLAVE_SLOTS          (slot_num_p                           ),
+    .C_NUM_MASTER_SLOTS         (1                                    ),
+    .C_AXI_ID_WIDTH             (id_width_p                           ),
+    .C_AXI_ADDR_WIDTH           (addr_width_p                         ),
+    .C_AXI_DATA_WIDTH           (data_width_p                         ),
+    .C_AXI_PROTOCOL             (0                                    ), // 0 is AXI4 Full
+    .C_NUM_ADDR_RANGES          (1                                    ),
+    .C_M_AXI_BASE_ADDR          (128'H00000000000000000000000000000000),
+    .C_M_AXI_ADDR_WIDTH         (64'H0000004000000040                 ),
+    .C_S_AXI_BASE_ID            (64'H0000000000000000                 ),
+    .C_S_AXI_THREAD_ID_WIDTH    (64'H0000000500000005                 ),
+    .C_AXI_SUPPORTS_USER_SIGNALS(0                                    ),
+    .C_AXI_AWUSER_WIDTH         (1                                    ),
+    .C_AXI_ARUSER_WIDTH         (1                                    ),
+    .C_AXI_WUSER_WIDTH          (1                                    ),
+    .C_AXI_RUSER_WIDTH          (1                                    ),
+    .C_AXI_BUSER_WIDTH          (1                                    ),
+    .C_M_AXI_WRITE_CONNECTIVITY (32'H00000003                         ),
+    .C_M_AXI_READ_CONNECTIVITY  (32'H00000003                         ),
+    .C_R_REGISTER               (0                                    ),
+    .C_S_AXI_SINGLE_THREAD      (64'H0000000000000000                 ),
+    .C_S_AXI_WRITE_ACCEPTANCE   (64'H0000000200000002                 ),
+    .C_S_AXI_READ_ACCEPTANCE    (64'H0000000200000002                 ),
+    .C_M_AXI_WRITE_ISSUING      (32'H00000004                         ),
+    .C_M_AXI_READ_ISSUING       (32'H00000004                         ),
+    .C_S_AXI_ARB_PRIORITY       (64'H0000000000000000                 ),
+    .C_M_AXI_SECURE             (32'H00000000                         ),
+    .C_CONNECTIVITY_MODE        (0                                    )
+  ) xbar (
+    .aclk          (clk_i                    ),
+    .aresetn       (~reset_i                 ),
+    .s_axi_awid    (s_axi_mux_i_cast.awid    ),
+    .s_axi_awaddr  (s_axi_mux_i_cast.awaddr  ),
+    .s_axi_awlen   (s_axi_mux_i_cast.awlen   ),
+    .s_axi_awsize  (s_axi_mux_i_cast.awsize  ),
+    .s_axi_awburst (s_axi_mux_i_cast.awburst ),
+    .s_axi_awlock  (s_axi_mux_i_cast.awlock  ),
+    .s_axi_awcache (s_axi_mux_i_cast.awcache ),
+    .s_axi_awprot  (s_axi_mux_i_cast.awprot  ),
+    .s_axi_awqos   (s_axi_mux_i_cast.awqos   ),
+    .s_axi_awuser  ('0                       ),
+    .s_axi_awvalid (s_axi_mux_i_cast.awvalid ),
+    .s_axi_awready (s_axi_mux_o_cast.awready ),
+    .s_axi_wid     ('0                       ),
+    .s_axi_wdata   (s_axi_mux_i_cast.wdata   ),
+    .s_axi_wstrb   (s_axi_mux_i_cast.wstrb   ),
+    .s_axi_wlast   (s_axi_mux_i_cast.wlast   ),
+    .s_axi_wuser   ('0                       ),
+    .s_axi_wvalid  (s_axi_mux_i_cast.wvalid  ),
+    .s_axi_wready  (s_axi_mux_o_cast.wready  ),
+    .s_axi_bid     (s_axi_mux_o_cast.bid     ),
+    .s_axi_bresp   (s_axi_mux_o_cast.bresp   ),
+    .s_axi_buser   (                         ),
+    .s_axi_bvalid  (s_axi_mux_o_cast.bvalid  ),
+    .s_axi_bready  (s_axi_mux_i_cast.bready  ),
+    .s_axi_arid    (s_axi_mux_i_cast.arid    ),
+    .s_axi_araddr  (s_axi_mux_i_cast.araddr  ),
+    .s_axi_arlen   (s_axi_mux_i_cast.arlen   ),
+    .s_axi_arsize  (s_axi_mux_i_cast.arsize  ),
+    .s_axi_arburst (s_axi_mux_i_cast.arburst ),
+    .s_axi_arlock  (s_axi_mux_i_cast.arlock  ),
+    .s_axi_arcache (s_axi_mux_i_cast.arcache ),
+    .s_axi_arprot  (s_axi_mux_i_cast.arprot  ),
+    .s_axi_arqos   (s_axi_mux_i_cast.arqos   ),
+    .s_axi_aruser  ('0                       ),
+    .s_axi_arvalid (s_axi_mux_i_cast.arvalid ),
+    .s_axi_arready (s_axi_mux_o_cast.arready ),
+    .s_axi_rid     (s_axi_mux_o_cast.rid     ),
+    .s_axi_rdata   (s_axi_mux_o_cast.rdata   ),
+    .s_axi_rresp   (s_axi_mux_o_cast.rresp   ),
+    .s_axi_rlast   (s_axi_mux_o_cast.rlast   ),
+    .s_axi_ruser   (                         ),
+    .s_axi_rvalid  (s_axi_mux_o_cast.rvalid  ),
+    .s_axi_rready  (s_axi_mux_i_cast.rready  ),
+    // master
+    .m_axi_awid    (m_axi_bus_o_cast.awid    ),
+    .m_axi_awaddr  (m_axi_bus_o_cast.awaddr  ),
+    .m_axi_awlen   (m_axi_bus_o_cast.awlen   ),
+    .m_axi_awsize  (m_axi_bus_o_cast.awsize  ),
+    .m_axi_awburst (m_axi_bus_o_cast.awburst ),
+    .m_axi_awlock  (m_axi_bus_o_cast.awlock  ),
+    .m_axi_awcache (m_axi_bus_o_cast.awcache ),
+    .m_axi_awprot  (m_axi_bus_o_cast.awprot  ),
+    .m_axi_awregion(m_axi_bus_o_cast.awregion),
+    .m_axi_awqos   (m_axi_bus_o_cast.awqos   ),
+    .m_axi_awuser  (                         ),
+    .m_axi_awvalid (m_axi_bus_o_cast.awvalid ),
+    .m_axi_awready (m_axi_bus_i_cast.awready ),
+    .m_axi_wid     (                         ),
+    .m_axi_wdata   (m_axi_bus_o_cast.wdata   ),
+    .m_axi_wstrb   (m_axi_bus_o_cast.wstrb   ),
+    .m_axi_wlast   (m_axi_bus_o_cast.wlast   ),
+    .m_axi_wuser   (                         ),
+    .m_axi_wvalid  (m_axi_bus_o_cast.wvalid  ),
+    .m_axi_wready  (m_axi_bus_i_cast.wready  ),
+    .m_axi_bid     (m_axi_bus_i_cast.bid     ),
+    .m_axi_bresp   (m_axi_bus_i_cast.bresp   ),
+    .m_axi_buser   ('0                       ),
+    .m_axi_bvalid  (m_axi_bus_i_cast.bvalid  ),
+    .m_axi_bready  (m_axi_bus_o_cast.bready  ),
+    .m_axi_arid    (m_axi_bus_o_cast.arid    ),
+    .m_axi_araddr  (m_axi_bus_o_cast.araddr  ),
+    .m_axi_arlen   (m_axi_bus_o_cast.arlen   ),
+    .m_axi_arsize  (m_axi_bus_o_cast.arsize  ),
+    .m_axi_arburst (m_axi_bus_o_cast.arburst ),
+    .m_axi_arlock  (m_axi_bus_o_cast.arlock  ),
+    .m_axi_arcache (m_axi_bus_o_cast.arcache ),
+    .m_axi_arprot  (m_axi_bus_o_cast.arprot  ),
+    .m_axi_arregion(m_axi_bus_o_cast.arregion),
+    .m_axi_arqos   (m_axi_bus_o_cast.arqos   ),
+    .m_axi_aruser  (                         ),
+    .m_axi_arvalid (m_axi_bus_o_cast.arvalid ),
+    .m_axi_arready (m_axi_bus_i_cast.arready ),
+    .m_axi_rid     (m_axi_bus_i_cast.rid     ),
+    .m_axi_rdata   (m_axi_bus_i_cast.rdata   ),
+    .m_axi_rresp   (m_axi_bus_i_cast.rresp   ),
+    .m_axi_rlast   (m_axi_bus_i_cast.rlast   ),
+    .m_axi_ruser   ('0                       ),
+    .m_axi_rvalid  (m_axi_bus_i_cast.rvalid  ),
+    .m_axi_rready  (m_axi_bus_o_cast.rready  )
+  );
+
+endmodule

--- a/hdl/bsg_axi_bus_pkg.vh
+++ b/hdl/bsg_axi_bus_pkg.vh
@@ -1,95 +1,114 @@
 `ifndef BSG_AXI_BUS_PKG_VH
 `define BSG_AXI_BUS_PKG_VH
 
+
+// -----------------------------------------------------------
+// AXI-Lite interface
+// -----------------------------------------------------------
 `define declare_bsg_axil_bus_s(slot_num_lp, mosi_struct_name, miso_struct_name) \
 typedef struct packed { \
   logic [slot_num_lp*32-1:0] awaddr ; \
   logic [   slot_num_lp-1:0] awvalid; \
-  logic [slot_num_lp*32-1:0] wdata  ; \
-  logic [ slot_num_lp*4-1:0] wstrb  ; \
-  logic [   slot_num_lp-1:0] wvalid ; \
+  \
+  logic [slot_num_lp*32-1:0] wdata ; \
+  logic [ slot_num_lp*4-1:0] wstrb ; \
+  logic [   slot_num_lp-1:0] wvalid; \
   \
   logic [slot_num_lp-1:0] bready; \
   \
   logic [slot_num_lp*32-1:0] araddr ; \
   logic [   slot_num_lp-1:0] arvalid; \
-  logic [   slot_num_lp-1:0] rready ; \
+  \
+  logic [slot_num_lp-1:0] rready; \
 } mosi_struct_name; \
 \
 typedef struct packed { \
   logic [slot_num_lp-1:0] awready; \
-  logic [slot_num_lp-1:0] wready ; \
+  \
+  logic [slot_num_lp-1:0] wready; \
   \
   logic [slot_num_lp*2-1:0] bresp ; \
   logic [  slot_num_lp-1:0] bvalid; \
   \
-  logic [   slot_num_lp-1:0] arready; \
-  logic [slot_num_lp*32-1:0] rdata  ; \
-  logic [ slot_num_lp*2-1:0] rresp  ; \
-  logic [   slot_num_lp-1:0] rvalid ; \
+  logic [slot_num_lp-1:0] arready; \
+  \
+  logic [slot_num_lp*32-1:0] rdata ; \
+  logic [ slot_num_lp*2-1:0] rresp ; \
+  logic [   slot_num_lp-1:0] rvalid; \
   \
 } miso_struct_name
 
-`define bsg_axil_mosi_bus_width(slot_num_lp) \
-( slot_num_lp * (3*32 + 5 + 4) \
-)
-
-`define bsg_axil_miso_bus_width(slot_num_lp) \
-( slot_num_lp * (5 + 2*2 + 32) \
-)
+`define bsg_axil_mosi_bus_width(slot_num_lp) (slot_num_lp * (3*32 + 5 + 4))
+`define bsg_axil_miso_bus_width(slot_num_lp) (slot_num_lp * (5 + 2*2 + 32))
 
 
+// -----------------------------------------------------------
+// AXI4-full interface (optional signals are disabled)
+// -----------------------------------------------------------
 `define declare_bsg_axi_bus_s(slot_num_lp, id_width_p, addr_width_p, data_width_p, mosi_struct_name, miso_struct_name) \
 typedef struct packed { \
-  logic [    slot_num_lp*id_width_p-1:0] awid   ; \
-  logic [  slot_num_lp*addr_width_p-1:0] awaddr ; \
-  logic [             slot_num_lp*8-1:0] awlen  ; \
-  logic [             slot_num_lp*3-1:0] awsize ; \
-  logic [               slot_num_lp-1:0] awvalid; \
-  logic [    slot_num_lp*id_width_p-1:0] wid    ; \
-  logic [  slot_num_lp*data_width_p-1:0] wdata  ; \
-  logic [slot_num_lp*data_width_p/8-1:0] wstrb  ; \
-  logic [               slot_num_lp-1:0] wlast  ; \
-  logic [               slot_num_lp-1:0] wvalid ; \
+  logic [  slot_num_lp*id_width_p-1:0] awid    ; \
+  logic [slot_num_lp*addr_width_p-1:0] awaddr  ; \
+  logic [           slot_num_lp*8-1:0] awlen   ; \
+  logic [           slot_num_lp*3-1:0] awsize  ; \
+  logic [           slot_num_lp*2-1:0] awburst ; \
+  logic [             slot_num_lp-1:0] awlock  ; \
+  logic [           slot_num_lp*4-1:0] awcache ; \
+  logic [           slot_num_lp*3-1:0] awprot  ; \
+  logic [           slot_num_lp*4-1:0] awqos   ; \
+  logic [           slot_num_lp*4-1:0] awregion; \
+  logic [             slot_num_lp-1:0] awvalid ; \
+  \
+  logic [  slot_num_lp*data_width_p-1:0] wdata ; \
+  logic [slot_num_lp*data_width_p/8-1:0] wstrb ; \
+  logic [               slot_num_lp-1:0] wlast ; \
+  logic [               slot_num_lp-1:0] wvalid; \
   \
   logic [slot_num_lp-1:0] bready; \
   \
-  logic [  slot_num_lp*id_width_p-1:0] arid   ; \
-  logic [slot_num_lp*addr_width_p-1:0] araddr ; \
-  logic [           slot_num_lp*8-1:0] arlen  ; \
-  logic [           slot_num_lp*3-1:0] arsize ; \
-  logic [             slot_num_lp-1:0] arvalid; \
-  logic [             slot_num_lp-1:0] rready ; \
+  logic [  slot_num_lp*id_width_p-1:0] arid    ; \
+  logic [slot_num_lp*addr_width_p-1:0] araddr  ; \
+  logic [           slot_num_lp*8-1:0] arlen   ; \
+  logic [           slot_num_lp*3-1:0] arsize  ; \
+  logic [           slot_num_lp*2-1:0] arburst ; \
+  logic [             slot_num_lp-1:0] arlock  ; \
+  logic [           slot_num_lp*4-1:0] arcache ; \
+  logic [           slot_num_lp*3-1:0] arprot  ; \
+  logic [           slot_num_lp*4-1:0] arqos   ; \
+  logic [           slot_num_lp*4-1:0] arregion; \
+  logic [             slot_num_lp-1:0] arvalid ; \
+  \
+  logic [slot_num_lp-1:0] rready; \
 } mosi_struct_name; \
 \
 typedef struct packed { \
   logic [slot_num_lp-1:0] awready; \
-  logic [slot_num_lp-1:0] wready ; \
+  \
+  logic [slot_num_lp-1:0] wready; \
   \
   logic [slot_num_lp*id_width_p-1:0] bid   ; \
   logic [         slot_num_lp*2-1:0] bresp ; \
   logic [           slot_num_lp-1:0] bvalid; \
-  logic [           slot_num_lp-1:0] bready; \
   \
-  logic [             slot_num_lp-1:0] arready; \
-  logic [  slot_num_lp*id_width_p-1:0] rid    ; \
-  logic [slot_num_lp*data_width_p-1:0] rdata  ; \
-  logic [           slot_num_lp*2-1:0] rresp  ; \
-  logic [             slot_num_lp-1:0] rlast  ; \
-  logic [             slot_num_lp-1:0] rvalid ; \
+  logic [slot_num_lp-1:0] arready; \
+  \
+  logic [  slot_num_lp*id_width_p-1:0] rid   ; \
+  logic [slot_num_lp*data_width_p-1:0] rdata ; \
+  logic [           slot_num_lp*2-1:0] rresp ; \
+  logic [             slot_num_lp-1:0] rlast ; \
+  logic [             slot_num_lp-1:0] rvalid; \
 } miso_struct_name
 
 `define bsg_axi_mosi_bus_width(slot_num_lp, id_width_p, addr_width_p, data_width_p) \
-( slot_num_lp * \
-  (3*id_width_p + 2*addr_width_p + 2*8 + 2*3 + 6 + data_width_p + data_width_p/8) \
-)
+( slot_num_lp * (2*id_width_p + 2*addr_width_p + 2*8 + 4*3 + 2*2 + 6*4 + 8 + data_width_p + data_width_p/8))
 
 `define bsg_axi_miso_bus_width(slot_num_lp, id_width_p, addr_width_p, data_width_p) \
-( slot_num_lp * \
-  (7 + 2*id_width_p + 2*2 + data_width_p) \
-)
+(slot_num_lp * (6 + 2*id_width_p + 2*2 + data_width_p))
 
 
+// -----------------------------------------------------------
+// AXI-Stream interface
+// -----------------------------------------------------------
 `define declare_bsg_axis_bus_s(data_width_p, mosi_struct_name, miso_struct_name) \
 typedef struct packed { \
   logic [  data_width_p-1:0] txd_tdata ; \
@@ -101,7 +120,7 @@ typedef struct packed { \
 } mosi_struct_name; \
 \
 typedef struct packed { \
-  logic txd_tready; \
+  logic                      txd_tready; \
   logic [  data_width_p-1:0] rxd_tdata ; \
   logic [data_width_p/8-1:0] rxd_tkeep ; \
   logic                      rxd_tlast ; \
@@ -109,6 +128,7 @@ typedef struct packed { \
 } miso_struct_name
 
 `define bsg_axis_bus_width(data_width_p) \
-  (data_width_p + 3 + data_width_p/8)
+(data_width_p + 3 + data_width_p/8)
+
 
 `endif

--- a/hdl/f1_bladerunner_ports.inc
+++ b/hdl/f1_bladerunner_ports.inc
@@ -1,0 +1,137 @@
+`include "bsg_axi_bus_pkg.vh"
+
+// ---------------------------------------------
+// axil ocl interface
+// ---------------------------------------------
+wire clk_i    = clk_main_a0    ;
+wire resetn_i = rst_main_n_sync;
+
+`declare_bsg_axil_bus_s(1, sh_ocl_si_s, sh_ocl_so_s);
+sh_ocl_si_s s_axil_ocl_li_cast;
+sh_ocl_so_s s_axil_ocl_lo_cast;
+
+assign s_axil_ocl_li_cast.awaddr  = sh_ocl_awaddr;
+assign s_axil_ocl_li_cast.awvalid = sh_ocl_awvalid;
+assign s_axil_ocl_li_cast.wdata   = sh_ocl_wdata;
+assign s_axil_ocl_li_cast.wstrb   = sh_ocl_wstrb;
+assign s_axil_ocl_li_cast.wvalid  = sh_ocl_wvalid;
+assign s_axil_ocl_li_cast.bready  = sh_ocl_bready;
+assign s_axil_ocl_li_cast.araddr  = sh_ocl_araddr;
+assign s_axil_ocl_li_cast.arvalid = sh_ocl_arvalid;
+assign s_axil_ocl_li_cast.rready  = sh_ocl_rready;
+
+assign ocl_sh_awready = s_axil_ocl_lo_cast.awready;
+assign ocl_sh_wready  = s_axil_ocl_lo_cast.wready;
+assign ocl_sh_bresp   = s_axil_ocl_lo_cast.bresp;
+assign ocl_sh_bvalid  = s_axil_ocl_lo_cast.bvalid;
+assign ocl_sh_arready = s_axil_ocl_lo_cast.arready;
+assign ocl_sh_rdata   = s_axil_ocl_lo_cast.rdata;
+assign ocl_sh_rresp   = s_axil_ocl_lo_cast.rresp;
+assign ocl_sh_rvalid  = s_axil_ocl_lo_cast.rvalid;
+
+
+// ---------------------------------------------
+// axi4 pcis interface
+// ---------------------------------------------
+
+`declare_bsg_axi_bus_s(1, axi_id_width_p, axi_addr_width_p, axi_data_width_p, axi_pcis_si_s, axi_pcis_so_s);
+axi_pcis_si_s s_axi_pcis_li_cast, m_axi_ddr_lo_cast;
+axi_pcis_so_s s_axi_pcis_lo_cast, m_axi_ddr_li_cast;
+
+// AXI4 pcis interface
+assign s_axi_pcis_li_cast.awid     = sh_cl_dma_pcis_awid;
+assign s_axi_pcis_li_cast.awaddr   = sh_cl_dma_pcis_awaddr;
+assign s_axi_pcis_li_cast.awlen    = sh_cl_dma_pcis_awlen;
+assign s_axi_pcis_li_cast.awsize   = sh_cl_dma_pcis_awsize;
+assign s_axi_pcis_li_cast.awburst  = 2'b01;
+assign s_axi_pcis_li_cast.awlock    = '0;
+assign s_axi_pcis_li_cast.awcache   = '0;
+assign s_axi_pcis_li_cast.awprot    = '0;
+assign s_axi_pcis_li_cast.awqos     = '0;
+assign s_axi_pcis_li_cast.awregion = '0;
+assign s_axi_pcis_li_cast.awvalid  = sh_cl_dma_pcis_awvalid;
+assign s_axi_pcis_li_cast.wdata    = sh_cl_dma_pcis_wdata;
+assign s_axi_pcis_li_cast.wstrb    = sh_cl_dma_pcis_wstrb;
+assign s_axi_pcis_li_cast.wlast    = sh_cl_dma_pcis_wlast;
+assign s_axi_pcis_li_cast.wvalid   = sh_cl_dma_pcis_wvalid;
+assign s_axi_pcis_li_cast.bready   = sh_cl_dma_pcis_bready;
+assign s_axi_pcis_li_cast.arid     = sh_cl_dma_pcis_arid;
+assign s_axi_pcis_li_cast.araddr   = sh_cl_dma_pcis_araddr;
+assign s_axi_pcis_li_cast.arlen    = sh_cl_dma_pcis_arlen;
+assign s_axi_pcis_li_cast.arsize   = sh_cl_dma_pcis_arsize;
+assign s_axi_pcis_li_cast.arburst  = 2'b01;
+assign s_axi_pcis_li_cast.arlock   = '0;
+assign s_axi_pcis_li_cast.arcache  = '0;
+assign s_axi_pcis_li_cast.arprot   = '0;
+assign s_axi_pcis_li_cast.arqos    = '0;
+assign s_axi_pcis_li_cast.arregion = '0;
+assign s_axi_pcis_li_cast.arvalid  = sh_cl_dma_pcis_arvalid;
+assign s_axi_pcis_li_cast.rready   = sh_cl_dma_pcis_rready;
+
+assign cl_sh_dma_pcis_awready = s_axi_pcis_lo_cast.awready;
+assign cl_sh_dma_pcis_wready  = s_axi_pcis_lo_cast.wready;
+assign cl_sh_dma_pcis_bid     = s_axi_pcis_lo_cast.bid;
+assign cl_sh_dma_pcis_bresp   = s_axi_pcis_lo_cast.bresp;
+assign cl_sh_dma_pcis_bvalid  = s_axi_pcis_lo_cast.bvalid;
+assign cl_sh_dma_pcis_arready = s_axi_pcis_lo_cast.arready;
+assign cl_sh_dma_pcis_rid     = s_axi_pcis_lo_cast.rid;
+assign cl_sh_dma_pcis_rdata   = s_axi_pcis_lo_cast.rdata;
+assign cl_sh_dma_pcis_rresp   = s_axi_pcis_lo_cast.rresp;
+assign cl_sh_dma_pcis_rlast   = s_axi_pcis_lo_cast.rlast;
+assign cl_sh_dma_pcis_rvalid  = s_axi_pcis_lo_cast.rvalid;
+
+
+// AXI4 DDR interface
+assign cl_sh_ddr_awid    = m_axi_ddr_lo_cast.awid;
+assign cl_sh_ddr_awaddr  = m_axi_ddr_lo_cast.awaddr;
+assign cl_sh_ddr_awlen   = m_axi_ddr_lo_cast.awlen;
+assign cl_sh_ddr_awsize  = m_axi_ddr_lo_cast.awsize;
+assign cl_sh_ddr_awburst = m_axi_ddr_lo_cast.awburst;  // Burst mode, only INCR is supported,
+assign cl_sh_ddr_awvalid = m_axi_ddr_lo_cast.awvalid;
+assign cl_sh_ddr_wdata   = m_axi_ddr_lo_cast.wdata;
+assign cl_sh_ddr_wstrb   = m_axi_ddr_lo_cast.wstrb;
+assign cl_sh_ddr_wlast   = m_axi_ddr_lo_cast.wlast;
+assign cl_sh_ddr_wvalid  = m_axi_ddr_lo_cast.wvalid;
+assign cl_sh_ddr_bready  = m_axi_ddr_lo_cast.bready;
+assign cl_sh_ddr_arid    = m_axi_ddr_lo_cast.arid;
+assign cl_sh_ddr_araddr  = m_axi_ddr_lo_cast.araddr;
+assign cl_sh_ddr_arlen   = m_axi_ddr_lo_cast.arlen;
+assign cl_sh_ddr_arsize  = m_axi_ddr_lo_cast.arsize;
+assign cl_sh_ddr_arburst = m_axi_ddr_lo_cast.arburst;  // Burst mode, only INCR is supported,
+assign cl_sh_ddr_arvalid = m_axi_ddr_lo_cast.arvalid;
+assign cl_sh_ddr_rready  = m_axi_ddr_lo_cast.rready;
+
+assign m_axi_ddr_li_cast.awready = sh_cl_ddr_awready;
+assign m_axi_ddr_li_cast.wready  = sh_cl_ddr_wready;
+assign m_axi_ddr_li_cast.bid     = sh_cl_ddr_bid;
+assign m_axi_ddr_li_cast.bresp   = sh_cl_ddr_bresp;
+assign m_axi_ddr_li_cast.bvalid  = sh_cl_ddr_bvalid;
+assign m_axi_ddr_li_cast.arready = sh_cl_ddr_arready;
+assign m_axi_ddr_li_cast.rid     = sh_cl_ddr_rid;
+assign m_axi_ddr_li_cast.rdata   = sh_cl_ddr_rdata;
+assign m_axi_ddr_li_cast.rresp   = sh_cl_ddr_rresp;
+assign m_axi_ddr_li_cast.rlast   = sh_cl_ddr_rlast;
+assign m_axi_ddr_li_cast.rvalid  = sh_cl_ddr_rvalid;
+
+// NOT USED in AXI4
+assign cl_sh_ddr_wid = '0;
+
+// synopsys translate_off
+initial begin
+  assert (axi_id_width_p == 6)
+    else begin
+      $error("## manycore axi id width width mismatches with the shell");
+      $finish();
+    end
+  assert (axi_addr_width_p == 64)
+    else begin
+      $error("## manycore axi address width mismatches with the shell");
+      $finish();
+    end
+  assert (axi_data_width_p == 512)
+    else begin
+      $error("## manycore axi data width mismatches with the shell");
+      $finish();
+    end
+end
+// synopsys translate_on

--- a/hdl/hb_mc_wrapper.v
+++ b/hdl/hb_mc_wrapper.v
@@ -1,0 +1,363 @@
+/**
+*  hb_mc_wrapper.v
+*
+*  top level wrapper for the manycore design
+*/
+
+`include "cl_manycore_pkg.v"
+import cl_manycore_pkg::*;
+
+`include "bsg_bladerunner_rom_pkg.vh"
+import bsg_bladerunner_rom_pkg::*;
+
+`include "bsg_manycore_packet.vh"
+`include "bsg_axi_bus_pkg.vh"
+
+module hb_mc_wrapper #(
+  parameter axi_id_width_p = "inv"
+  , parameter axi_addr_width_p = "inv"
+  , parameter axi_data_width_p = "inv"
+  , localparam axil_mosi_bus_width_lp = `bsg_axil_mosi_bus_width(1)
+  , localparam axil_miso_bus_width_lp = `bsg_axil_miso_bus_width(1)
+  , localparam axi_mosi_bus_width_lp = `bsg_axi_mosi_bus_width(1, axi_id_width_p, axi_addr_width_p, axi_data_width_p)
+  , localparam axi_miso_bus_width_lp = `bsg_axi_miso_bus_width(1, axi_id_width_p, axi_addr_width_p, axi_data_width_p)
+) (
+  input                               clk_i
+  ,input                               resetn_i
+  ,input  [axil_mosi_bus_width_lp-1:0] s_axil_ocl_bus_i
+  ,output [axil_miso_bus_width_lp-1:0] s_axil_ocl_bus_o
+  ,input  [ axi_mosi_bus_width_lp-1:0] s_axi_pcis_bus_i
+  ,output [ axi_miso_bus_width_lp-1:0] s_axi_pcis_bus_o
+  ,output [ axi_mosi_bus_width_lp-1:0] m_axi_ddr_bus_o
+  ,input  [ axi_miso_bus_width_lp-1:0] m_axi_ddr_bus_i
+);
+
+  `declare_bsg_axil_bus_s(1, bsg_axil_mosi_bus_s, bsg_axil_miso_bus_s);
+  bsg_axil_mosi_bus_s s_axil_ocl_bus_li_cast, m_axil_bus_lo_cast;
+  bsg_axil_miso_bus_s s_axil_ocl_bus_lo_cast, m_axil_bus_li_cast;
+
+  assign s_axil_ocl_bus_li_cast = s_axil_ocl_bus_i;
+  assign s_axil_ocl_bus_o       = s_axil_ocl_bus_lo_cast;
+
+// -------------------------------------------------
+// AXI-Lite register
+// -------------------------------------------------
+
+  (* dont_touch = "true" *) logic axi_reg_rstn;
+  lib_pipe #(.WIDTH(1), .STAGES(4)) AXI_REG_RST_N (
+    .clk    (clk_i       )
+    ,.rst_n  (1'b1        )
+    ,.in_bus (resetn_i    )
+    ,.out_bus(axi_reg_rstn)
+  );
+
+  axi_register_slice_light AXIL_OCL_REG_SLC (
+    .aclk         (clk_i                         )
+    ,.aresetn      (axi_reg_rstn                  )
+    ,.s_axi_awaddr (s_axil_ocl_bus_li_cast.awaddr )
+    ,.s_axi_awprot (3'h0                          )
+    ,.s_axi_awvalid(s_axil_ocl_bus_li_cast.awvalid)
+    ,.s_axi_awready(s_axil_ocl_bus_lo_cast.awready)
+    ,.s_axi_wdata  (s_axil_ocl_bus_li_cast.wdata  )
+    ,.s_axi_wstrb  (s_axil_ocl_bus_li_cast.wstrb  )
+    ,.s_axi_wvalid (s_axil_ocl_bus_li_cast.wvalid )
+    ,.s_axi_wready (s_axil_ocl_bus_lo_cast.wready )
+    ,.s_axi_bresp  (s_axil_ocl_bus_lo_cast.bresp  )
+    ,.s_axi_bvalid (s_axil_ocl_bus_lo_cast.bvalid )
+    ,.s_axi_bready (s_axil_ocl_bus_li_cast.bready )
+    ,.s_axi_araddr (s_axil_ocl_bus_li_cast.araddr )
+    ,.s_axi_arprot (3'h0                          )
+    ,.s_axi_arvalid(s_axil_ocl_bus_li_cast.arvalid)
+    ,.s_axi_arready(s_axil_ocl_bus_lo_cast.arready)
+    ,.s_axi_rdata  (s_axil_ocl_bus_lo_cast.rdata  )
+    ,.s_axi_rresp  (s_axil_ocl_bus_lo_cast.rresp  )
+    ,.s_axi_rvalid (s_axil_ocl_bus_lo_cast.rvalid )
+    ,.s_axi_rready (s_axil_ocl_bus_li_cast.rready )
+    ,.m_axi_awaddr (m_axil_bus_lo_cast.awaddr     )
+    ,.m_axi_awprot (                              )
+    ,.m_axi_awvalid(m_axil_bus_lo_cast.awvalid    )
+    ,.m_axi_awready(m_axil_bus_li_cast.awready    )
+    ,.m_axi_wdata  (m_axil_bus_lo_cast.wdata      )
+    ,.m_axi_wstrb  (m_axil_bus_lo_cast.wstrb      )
+    ,.m_axi_wvalid (m_axil_bus_lo_cast.wvalid     )
+    ,.m_axi_wready (m_axil_bus_li_cast.wready     )
+    ,.m_axi_bresp  (m_axil_bus_li_cast.bresp      )
+    ,.m_axi_bvalid (m_axil_bus_li_cast.bvalid     )
+    ,.m_axi_bready (m_axil_bus_lo_cast.bready     )
+    ,.m_axi_araddr (m_axil_bus_lo_cast.araddr     )
+    ,.m_axi_arprot (                              )
+    ,.m_axi_arvalid(m_axil_bus_lo_cast.arvalid    )
+    ,.m_axi_arready(m_axil_bus_li_cast.arready    )
+    ,.m_axi_rdata  (m_axil_bus_li_cast.rdata      )
+    ,.m_axi_rresp  (m_axil_bus_li_cast.rresp      )
+    ,.m_axi_rvalid (m_axil_bus_li_cast.rvalid     )
+    ,.m_axi_rready (m_axil_bus_lo_cast.rready     )
+  );
+
+
+// -----------------------------------------------------------------
+// Manycore link
+// -----------------------------------------------------------------
+
+  localparam num_endpoint_lp = 1  ;
+  localparam fifo_width_lp   = 128;
+
+  localparam num_fifo_pair_lp = num_endpoint_lp*2;
+
+  (* dont_touch = "true" *) logic axi_mcl_rstn;
+  lib_pipe #(.WIDTH(1), .STAGES(4)) AXI_MCL_RST_N (
+    .clk    (clk_i       ),
+    .rst_n  (1'b1        ),
+    .in_bus (resetn_i    ),
+    .out_bus(axi_mcl_rstn)
+  );
+
+  `declare_bsg_manycore_link_sif_s(addr_width_p, data_width_p, x_cord_width_p, y_cord_width_p, load_id_width_p);
+
+  bsg_manycore_link_sif_s loader_link_sif_lo;
+  bsg_manycore_link_sif_s loader_link_sif_li;
+
+  logic [1-1:0][x_cord_width_p-1:0] mcl_x_cord_lp = x_cord_width_p'(num_tiles_x_p-1);
+  logic [1-1:0][y_cord_width_p-1:0] mcl_y_cord_lp = '0                              ;
+
+axil_to_mcl #(
+  .num_mcl_p        (1                )
+  ,.num_tiles_x_p    (num_tiles_x_p    )
+  ,.num_tiles_y_p    (num_tiles_y_p    )
+  ,.addr_width_p     (addr_width_p     )
+  ,.data_width_p     (data_width_p     )
+  ,.x_cord_width_p   (x_cord_width_p   )
+  ,.y_cord_width_p   (y_cord_width_p   )
+  ,.load_id_width_p  (load_id_width_p  )
+  ,.max_out_credits_p(max_out_credits_p)
+) axil_to_mcl_inst (
+  .clk_i             (clk_i                     )
+  ,.reset_i           (~axi_mcl_rstn             )
+  ,// axil slave interface
+  .s_axil_mcl_awvalid(m_axil_bus_lo_cast.awvalid)
+  ,.s_axil_mcl_awaddr (m_axil_bus_lo_cast.awaddr )
+  ,.s_axil_mcl_awready(m_axil_bus_li_cast.awready)
+  ,.s_axil_mcl_wvalid (m_axil_bus_lo_cast.wvalid )
+  ,.s_axil_mcl_wdata  (m_axil_bus_lo_cast.wdata  )
+  ,.s_axil_mcl_wstrb  (m_axil_bus_lo_cast.wstrb  )
+  ,.s_axil_mcl_wready (m_axil_bus_li_cast.wready )
+  ,.s_axil_mcl_bresp  (m_axil_bus_li_cast.bresp  )
+  ,.s_axil_mcl_bvalid (m_axil_bus_li_cast.bvalid )
+  ,.s_axil_mcl_bready (m_axil_bus_lo_cast.bready )
+  ,.s_axil_mcl_araddr (m_axil_bus_lo_cast.araddr )
+  ,.s_axil_mcl_arvalid(m_axil_bus_lo_cast.arvalid)
+  ,.s_axil_mcl_arready(m_axil_bus_li_cast.arready)
+  ,.s_axil_mcl_rdata  (m_axil_bus_li_cast.rdata  )
+  ,.s_axil_mcl_rresp  (m_axil_bus_li_cast.rresp  )
+  ,.s_axil_mcl_rvalid (m_axil_bus_li_cast.rvalid )
+  ,.s_axil_mcl_rready (m_axil_bus_lo_cast.rready )
+
+  ,.link_sif_i        (loader_link_sif_lo        )
+  ,.link_sif_o        (loader_link_sif_li        )
+  ,.my_x_i            (mcl_x_cord_lp             )
+  ,.my_y_i            (mcl_y_cord_lp             )
+);
+
+
+  // -------------------------------------------------------------------
+  // -------------------------------------------------------------------
+  //                            MANYCORE
+  // -------------------------------------------------------------------
+  // -------------------------------------------------------------------
+
+  (* dont_touch = "true" *) logic axi_hb_mc_rstn;
+  lib_pipe #(.WIDTH(1), .STAGES(4)) AXI_HB_MC_RST_N (
+    .clk    (clk_i       ),
+    .rst_n  (1'b1        ),
+    .in_bus (resetn_i    ),
+    .out_bus(axi_hb_mc_rstn)
+  );
+
+  // rom
+  bsg_manycore_link_sif_s rom_link_sif_li;
+  bsg_manycore_link_sif_s rom_link_sif_lo;
+
+  logic [x_cord_width_p-1:0] rom_x_cord_lp = '0;
+  logic [y_cord_width_p-1:0] rom_y_cord_lp = '0;
+
+  // cache
+  bsg_manycore_link_sif_s [num_cache_p-1:0] cache_link_sif_li;
+  bsg_manycore_link_sif_s [num_cache_p-1:0] cache_link_sif_lo;
+
+  logic [num_cache_p-1:0][x_cord_width_p-1:0] cache_x_lo;
+  logic [num_cache_p-1:0][y_cord_width_p-1:0] cache_y_lo;
+
+  bsg_manycore_wrapper #(
+    .addr_width_p         (addr_width_p         )
+    ,.data_width_p         (data_width_p         )
+    ,.num_tiles_x_p        (num_tiles_x_p        )
+    ,.num_tiles_y_p        (num_tiles_y_p        )
+    ,.dmem_size_p          (dmem_size_p          )
+    ,.icache_entries_p     (icache_entries_p     )
+    ,.icache_tag_width_p   (icache_tag_width_p   )
+    ,.epa_byte_addr_width_p(epa_byte_addr_width_p)
+    ,.dram_ch_addr_width_p (dram_ch_addr_width_p )
+    ,.load_id_width_p      (load_id_width_p      )
+    ,.num_cache_p          (num_cache_p          )
+  ) manycore_wrapper (
+    .clk_i            (clk_i             )
+    ,.reset_i          (~axi_hb_mc_rstn   )
+    ,.cache_link_sif_i (cache_link_sif_li )
+    ,.cache_link_sif_o (cache_link_sif_lo )
+    ,.cache_x_o        (cache_x_lo        )
+    ,.cache_y_o        (cache_y_lo        )
+    ,.loader_link_sif_i(loader_link_sif_li)
+    ,.loader_link_sif_o(loader_link_sif_lo)
+    ,.rom_link_sif_i   (rom_link_sif_li   )
+    ,.rom_link_sif_o   (rom_link_sif_lo   )
+  );
+
+
+  // -------------------------------------------------
+  // bladerunner configuration rom
+  // -------------------------------------------------
+  bsg_bladerunner_rom #(
+    .rom_width_p    (rom_width_p    )
+    ,.rom_els_p      (rom_els_p      )
+    ,.x_cord_width_p (x_cord_width_p )
+    ,.y_cord_width_p (y_cord_width_p )
+    ,.addr_width_p   (addr_width_p   )
+    ,.data_width_p   (data_width_p   )
+    ,.load_id_width_p(load_id_width_p)
+  ) bladerunner_rom (
+    .clk_i     (clk_i          )
+    ,.reset_i   (~axi_hb_mc_rstn)
+    ,.my_x_i    (rom_x_cord_lp  )
+    ,.my_y_i    (rom_y_cord_lp  )
+    ,.link_sif_i(rom_link_sif_lo)
+    ,.link_sif_o(rom_link_sif_li)
+  );
+
+
+  `declare_bsg_axi_bus_s(1, axi_id_width_p, axi_addr_width_p, axi_data_width_p, bsg_axi_mosi_bus_s, bsg_axi_miso_bus_s);
+
+  // -------------------------------------------------
+  // cache module
+  // -------------------------------------------------
+  bsg_axi_mosi_bus_s m_axi_mc_lo_cast;
+  bsg_axi_miso_bus_s m_axi_mc_li_cast;
+
+  bsg_cache_wrapper_axi #(
+    .num_cache_p          (num_cache_p          )
+    ,.data_width_p         (data_width_p         )
+    ,.addr_width_p         (addr_width_p         )
+    ,.block_size_in_words_p(block_size_in_words_p)
+    ,.sets_p               (sets_p               )
+    ,.ways_p               (ways_p               )
+    ,.axi_id_width_p       (axi_id_width_p       )
+    ,.axi_addr_width_p     (axi_addr_width_p     )
+    ,.axi_data_width_p     (axi_data_width_p     )
+    ,.axi_burst_len_p      (axi_burst_len_p      )
+    ,.x_cord_width_p       (x_cord_width_p       )
+    ,.y_cord_width_p       (y_cord_width_p       )
+    ,.load_id_width_p      (load_id_width_p      )
+  ) cache_wrapper (
+    .clk_i        (clk_i                   )
+    ,.reset_i      (~axi_hb_mc_rstn         )
+    ,.my_x_i       (cache_x_lo              )
+    ,.my_y_i       (cache_y_lo              )
+    ,.link_sif_i   (cache_link_sif_lo       )
+    ,.link_sif_o   (cache_link_sif_li       )
+
+    ,.axi_awid_o   (m_axi_mc_lo_cast.awid   )
+    ,.axi_awaddr_o (m_axi_mc_lo_cast.awaddr )
+    ,.axi_awlen_o  (m_axi_mc_lo_cast.awlen  )
+    ,.axi_awsize_o (m_axi_mc_lo_cast.awsize )
+    ,.axi_awburst_o(m_axi_mc_lo_cast.awburst)
+    ,.axi_awcache_o(m_axi_mc_lo_cast.awcache)
+    ,.axi_awprot_o (m_axi_mc_lo_cast.awprot )
+    ,.axi_awlock_o (m_axi_mc_lo_cast.awlock )
+    ,.axi_awvalid_o(m_axi_mc_lo_cast.awvalid)
+    ,.axi_awready_i(m_axi_mc_li_cast.awready)
+
+    ,.axi_wdata_o  (m_axi_mc_lo_cast.wdata  )
+    ,.axi_wstrb_o  (m_axi_mc_lo_cast.wstrb  )
+    ,.axi_wlast_o  (m_axi_mc_lo_cast.wlast  )
+    ,.axi_wvalid_o (m_axi_mc_lo_cast.wvalid )
+    ,.axi_wready_i (m_axi_mc_li_cast.wready )
+
+    ,.axi_bid_i    (m_axi_mc_li_cast.bid    )
+    ,.axi_bresp_i  (m_axi_mc_li_cast.bresp  )
+    ,.axi_bvalid_i (m_axi_mc_li_cast.bvalid )
+    ,.axi_bready_o (m_axi_mc_lo_cast.bready )
+
+    ,.axi_arid_o   (m_axi_mc_lo_cast.arid   )
+    ,.axi_araddr_o (m_axi_mc_lo_cast.araddr )
+    ,.axi_arlen_o  (m_axi_mc_lo_cast.arlen  )
+    ,.axi_arsize_o (m_axi_mc_lo_cast.arsize )
+    ,.axi_arburst_o(m_axi_mc_lo_cast.arburst)
+    ,.axi_arcache_o(m_axi_mc_lo_cast.arcache)
+    ,.axi_arprot_o (m_axi_mc_lo_cast.arprot )
+    ,.axi_arlock_o (m_axi_mc_lo_cast.arlock )
+    ,.axi_arvalid_o(m_axi_mc_lo_cast.arvalid)
+    ,.axi_arready_i(m_axi_mc_li_cast.arready)
+
+    ,.axi_rid_i    (m_axi_mc_li_cast.rid    )
+    ,.axi_rdata_i  (m_axi_mc_li_cast.rdata  )
+    ,.axi_rresp_i  (m_axi_mc_li_cast.rresp  )
+    ,.axi_rlast_i  (m_axi_mc_li_cast.rlast  )
+    ,.axi_rvalid_i (m_axi_mc_li_cast.rvalid )
+    ,.axi_rready_o (m_axi_mc_lo_cast.rready )
+  );
+
+  assign m_axi_mc_lo_cast.awregion = 4'b0;
+  assign m_axi_mc_lo_cast.awqos    = 4'b0;
+
+  assign m_axi_mc_lo_cast.arregion = 4'b0;
+  assign m_axi_mc_lo_cast.arqos    = 4'b0;
+  // -------------------------------------------------------------------
+  // -------------------------------------------------------------------
+  //                      END OF MANYCORE
+  // -------------------------------------------------------------------
+  // -------------------------------------------------------------------
+
+
+  // --------------------------------------------------------------
+  // AXI4 PCIS from shell
+  // --------------------------------------------------------------
+
+  bsg_axi_mosi_bus_s s_axi_pcis_li_cast;
+  bsg_axi_miso_bus_s s_axi_pcis_lo_cast;
+
+  bsg_axi_mosi_bus_s m_axi_ddr_lo_cast;
+  bsg_axi_miso_bus_s m_axi_ddr_li_cast;
+
+  assign s_axi_pcis_li_cast = s_axi_pcis_bus_i;
+  assign s_axi_pcis_bus_o   = s_axi_pcis_lo_cast;
+
+  (* dont_touch = "true" *) logic axi_mux_rstn;
+  lib_pipe #(.WIDTH(1), .STAGES(4)) AXI4_MUX_RST_N (
+    .clk    (clk_i        )
+    ,.rst_n  (1'b1         )
+    ,.in_bus (resetn_i     )
+    ,.out_bus(axi_mux_rstn)
+  );
+
+  localparam slot_num_lp = 2;
+
+  axi_mux #(
+    .slot_num_p  (slot_num_lp     )
+    ,.id_width_p  (axi_id_width_p  )
+    ,.addr_width_p(axi_addr_width_p)
+    ,.data_width_p(axi_data_width_p)
+  ) axi_multiplexer (
+    .clk_i      (clk_i                                 )
+    ,.reset_i    (~axi_mux_rstn                         )
+    ,.s_axi_mux_i({m_axi_mc_lo_cast, s_axi_pcis_li_cast})
+    ,.s_axi_mux_o({m_axi_mc_li_cast, s_axi_pcis_lo_cast})
+    ,.m_axi_bus_o(m_axi_ddr_lo_cast                     )
+    ,.m_axi_bus_i(m_axi_ddr_li_cast                     )
+  );
+
+  // --------------------------------------------------------------
+  // AXI4 DDR to the RAM
+  // --------------------------------------------------------------
+  assign m_axi_ddr_bus_o   = m_axi_ddr_lo_cast;
+  assign m_axi_ddr_li_cast = m_axi_ddr_bus_i;
+
+endmodule // hb_mc_wrapper

--- a/hdl/s_axil_mcl_adapter.v
+++ b/hdl/s_axil_mcl_adapter.v
@@ -57,7 +57,7 @@ axi_register_slice_light AXIL_OCL_REG_SLC (
   .s_axi_rresp  (s_axil_mcl_bus_o_cast.rresp  ),
   .s_axi_rvalid (s_axil_mcl_bus_o_cast.rvalid ),
   .s_axi_rready (s_axil_mcl_bus_i_cast.rready ),
-  
+
   .m_axi_awaddr (s_axil_mcl_mosi_r.awaddr     ),
   .m_axi_awprot (                             ),
   .m_axi_awvalid(s_axil_mcl_mosi_r.awvalid    ),
@@ -89,6 +89,7 @@ bsg_axisN_miso_bus_s  miso_axisN_bus ;
 
 // convert axil to axis
 //---------------------------------
+`ifdef BSG_TARGET_F1
 axi_fifo_mm_s #(
   .C_FAMILY              (fpga_version_p),
   .C_S_AXI_ID_WIDTH      (4             ),
@@ -181,6 +182,45 @@ axi_fifo_mm_s #(
   .axi_str_rxd_tid       (4'h0                      ),
   .axi_str_rxd_tuser     (4'h0                      )
 );
+`else
+axi_fifo_mm_s_0 axi_fifo_mm_s_axi_lite (
+  .interrupt( ),                            // output wire interrupt
+  .s_axi_aclk(clk_i),                          // input wire s_axi_aclk
+  .s_axi_aresetn(~reset_i),                    // input wire s_axi_aresetn
+  .s_axi_awaddr(s_axil_mcl_mosi_r.awaddr),                      // input wire [31 : 0] s_axi_awaddr
+  .s_axi_awvalid(s_axil_mcl_mosi_r.awvalid),                    // input wire s_axi_awvalid
+  .s_axi_awready(s_axil_mcl_miso_r.awready),                    // output wire s_axi_awready
+  .s_axi_wdata(s_axil_mcl_mosi_r.wdata),                        // input wire [31 : 0] s_axi_wdata
+  .s_axi_wstrb(s_axil_mcl_mosi_r.wstrb),                        // input wire [3 : 0] s_axi_wstrb
+  .s_axi_wvalid(s_axil_mcl_mosi_r.wvalid),                      // input wire s_axi_wvalid
+  .s_axi_wready(s_axil_mcl_miso_r.wready),                      // output wire s_axi_wready
+  .s_axi_bresp(s_axil_mcl_miso_r.bresp),                        // output wire [1 : 0] s_axi_bresp
+  .s_axi_bvalid(s_axil_mcl_miso_r.bvalid),                      // output wire s_axi_bvalid
+  .s_axi_bready(s_axil_mcl_mosi_r.bready),                      // input wire s_axi_bready
+  .s_axi_araddr(s_axil_mcl_mosi_r.araddr),                      // input wire [31 : 0] s_axi_araddr
+  .s_axi_arvalid(s_axil_mcl_mosi_r.arvalid),                    // input wire s_axi_arvalid
+  .s_axi_arready(s_axil_mcl_miso_r.arready),                    // output wire s_axi_arready
+  .s_axi_rdata(s_axil_mcl_miso_r.rdata),                        // output wire [31 : 0] s_axi_rdata
+  .s_axi_rresp(s_axil_mcl_miso_r.rresp),                        // output wire [1 : 0] s_axi_rresp
+  .s_axi_rvalid(s_axil_mcl_miso_r.rvalid),                      // output wire s_axi_rvalid
+  .s_axi_rready(s_axil_mcl_mosi_r.rready),                      // input wire s_axi_rready
+  .mm2s_prmry_reset_out_n( ),  // output wire mm2s_prmry_reset_out_n
+  .axi_str_txd_tvalid(mosi_axis32_bus.txd_tvalid),          // output wire axi_str_txd_tvalid
+  .axi_str_txd_tready(miso_axis32_bus.txd_tready),          // input wire axi_str_txd_tready
+  .axi_str_txd_tlast(mosi_axis32_bus.txd_tlast ),            // output wire axi_str_txd_tlast
+  .axi_str_txd_tdata(mosi_axis32_bus.txd_tdata),            // output wire [31 : 0] axi_str_txd_tdata
+  .mm2s_cntrl_reset_out_n( ),  // output wire mm2s_cntrl_reset_out_n
+  .axi_str_txc_tvalid( ),          // output wire axi_str_txc_tvalid
+  .axi_str_txc_tready(1'h0 ),          // input wire axi_str_txc_tready
+  .axi_str_txc_tlast( ),            // output wire axi_str_txc_tlast
+  .axi_str_txc_tdata( ),            // output wire [31 : 0] axi_str_txc_tdata
+  .s2mm_prmry_reset_out_n( ),  // output wire s2mm_prmry_reset_out_n
+  .axi_str_rxd_tvalid(miso_axis32_bus.rxd_tvalid),          // input wire axi_str_rxd_tvalid
+  .axi_str_rxd_tready(mosi_axis32_bus.rxd_tready),          // output wire axi_str_rxd_tready
+  .axi_str_rxd_tlast(miso_axis32_bus.rxd_tlast),            // input wire axi_str_rxd_tlast
+  .axi_str_rxd_tdata(miso_axis32_bus.rxd_tdata)            // input wire [31 : 0] axi_str_rxd_tdata
+);
+`endif
 /*
    ila_0 CL_ILA_0 (
                    .clk    (clk_i),


### PR DESCRIPTION
issue #196 
1. Add the AXI wrapper for manycore/cache/manycore_link at the top level; extensively use AXI macros.
2. Add BSG_TARGET_F1 flag to select the source for different implementation platforms (F1 or vcu128 board).

Dependency: 
bsg_manycore: c179c82
basejump_stl: de58dc4

Regression test passed (cosim).