### PR TITLE
New hb_mc_symbol_to_eva function to new API

### DIFF
--- a/cl_manycore/libraries/bsg_manycore_elf.h
+++ b/cl_manycore/libraries/bsg_manycore_elf.h
@@ -7,6 +7,7 @@
 extern "C" {
 #endif
 
+__attribute__((deprecated))
 int symbol_to_eva(const char *fname, const char *sym_name, eva_t *eva);
 
 #ifdef __cplusplus

--- a/cl_manycore/libraries/bsg_manycore_errno.h
+++ b/cl_manycore/libraries/bsg_manycore_errno.h
@@ -11,9 +11,10 @@ extern "C" {
 #define HB_MC_TIMEOUT       (-2)
 #define HB_MC_UNINITIALIZED (-3)
 #define HB_MC_INVALID       (-4)
+#define HB_MC_INITIALIZED_TWICE (-4) // same as invalid
 #define HB_MC_NOMEM         (-5)
-#define HB_MC_INITIALIZED_TWICE (-6)
-#define HB_MC_NOIMPL (-7)
+#define HB_MC_NOIMPL        (-6)
+#define HB_MC_NOTFOUND      (-7)
 
 static inline const char * hb_mc_strerror(int err)
 {
@@ -21,11 +22,11 @@ static inline const char * hb_mc_strerror(int err)
                 [-HB_MC_SUCCESS]           = "Success",
                 [-HB_MC_FAIL]              = "Failure",
                 [-HB_MC_TIMEOUT]           = "Timeout",
-		[-HB_MC_UNINITIALIZED]     = "Manycore not initialized",
+		[-HB_MC_UNINITIALIZED]     = "Not initialized",
 		[-HB_MC_INVALID]           = "Invalid input",
 		[-HB_MC_NOMEM]             = "Out of memory",
-		[-HB_MC_INITIALIZED_TWICE] = "Non-zeroed input",
 		[-HB_MC_NOIMPL]            = "Not implemented",
+                [-HB_MC_NOTFOUND]          = "Not found",
         };
         return strtab[-err];
 }

--- a/cl_manycore/libraries/bsg_manycore_loader.h
+++ b/cl_manycore/libraries/bsg_manycore_loader.h
@@ -26,6 +26,17 @@ int hb_mc_loader_load(const void *bin, size_t sz,
 		const hb_mc_coordinate_t *tiles, 
 		uint32_t len);
 
+/**
+ * Get an EVA for a symbol from a program data.
+ * @param[in]  bin     A memory buffer containing a valid manycore binary.
+ * @param[in]  sz      Size of #bin in bytes.
+ * @param[in]  symbol  A program symbol. Behavior is undefined if #symbol is not a zero terminated string.
+ * @param[out] eva     An EVA that addresses #symbol. Behavior is undefined if #eva is invalid.
+ * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
+ */
+int hb_mc_loader_symbol_to_eva(const void *bin, size_t sz, const char *symbol,
+                               hb_mc_eva_t *eva);
+
 #ifdef __cplusplus
 }
 #endif

--- a/cl_manycore/regression/spmd/Makefile.tests
+++ b/cl_manycore/regression/spmd/Makefile.tests
@@ -1,5 +1,6 @@
 REGRESSION_TESTS_TYPE = spmd
-C_REGRESSION_TESTS = test_bsg_dram_loopback_cache
+C_REGRESSION_TESTS := test_bsg_dram_loopback_cache
+C_REGRESSION_TESTS += test_symbol_to_eva
 CXX_REGRESSION_TESTS = 
 
 REGRESSION_DEFINES = -DBSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR) \

--- a/cl_manycore/regression/spmd/test_symbol_to_eva.h
+++ b/cl_manycore/regression/spmd/test_symbol_to_eva.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <stdio.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <string.h>
+#include <time.h>
+#include <stdlib.h>
+#include "spmd_tests.h"


### PR DESCRIPTION
* hb_mc_symbol_to_eva() is like symbol_to_eva() but takes a buffer as input instead of a file path.