### PR TITLE
Moved CL_DIR Definition from root Makefile to Makefile.environment

### DIFF
--- a/cl_manycore/Makefile
+++ b/cl_manycore/Makefile
@@ -1,5 +1,4 @@
 PROJECT = cl_manycore
-include Makefile.environment
 
 # Image version is set by Bladerunner Makefile
 FPGA_IMAGE_VERSION ?= 0.0.0 

--- a/cl_manycore/Makefile
+++ b/cl_manycore/Makefile
@@ -1,11 +1,9 @@
-CL_DIR = $(CURDIR)
 PROJECT = cl_manycore
+include Makefile.environment
 
 # Image version is set by Bladerunner Makefile
 FPGA_IMAGE_VERSION ?= 0.0.0 
 CL_MANYCORE_RELEASE_VERSION  ?= $(shell echo $(FPGA_IMAGE_VERSION) | sed 's/\([0-9]*\)\.\([0-9]*\).\([0-9]*\)/000\10\20\3/')
-
-include $(CL_DIR)/Makefile.environment
 
 DEBUG ?= 
 AXI_MEMORY_MODEL ?= 1
@@ -16,20 +14,20 @@ all: $(SIM_TARGETS) $(BUILD_TARGETS)
 .PHONY: build regression hardware
 
 build:
-	$(MAKE) -C $@ CL_DIR=$(CL_DIR) PROJECT=$(PROJECT) CL_MANYCORE_RELEASE_VERSION=$(CL_MANYCORE_RELEASE_VERSION)
+	$(MAKE) -C $@ PROJECT=$(PROJECT) CL_MANYCORE_RELEASE_VERSION=$(CL_MANYCORE_RELEASE_VERSION)
 
 regression:
-	$(MAKE) -C regression $@ CL_DIR=$(CL_DIR) 
+	$(MAKE) -C regression $@ 
 
 hardware:
-	$(MAKE) -C hardware $@ CL_DIR=$(CL_DIR) 
+	$(MAKE) -C hardware $@ 
 
 cosim: 
-	$(MAKE) -C testbenches $@ CL_DIR=$(CL_DIR) DEBUG=$(DEBUG) AXI_MEMORY_MODEL=$(AXI_MEMORY_MODEL) AXI_PROT_CHECK=$(AXI_PROT_CHECK)
+	$(MAKE) -C testbenches $@ DEBUG=$(DEBUG) AXI_MEMORY_MODEL=$(AXI_MEMORY_MODEL) AXI_PROT_CHECK=$(AXI_PROT_CHECK)
 
 clean:
-	$(MAKE) -C testbenches clean CL_DIR=$(CL_DIR) PROJECT=$(PROJECT)
-	$(MAKE) -C build clean CL_DIR=$(CL_DIR) PROJECT=$(PROJECT) 
-	$(MAKE) -C regression clean CL_DIR=$(CL_DIR) 
-	$(MAKE) -C hardware clean CL_DIR=$(CL_DIR) 
+	$(MAKE) -C testbenches clean 
+	$(MAKE) -C build clean 
+	$(MAKE) -C regression clean
+	$(MAKE) -C hardware clean 
 

--- a/cl_manycore/Makefile.environment
+++ b/cl_manycore/Makefile.environment
@@ -2,21 +2,22 @@ ifndef HDK_DIR
 $(error "HDK variables undefined. Run `source hdk_setup.sh` in aws-fpga")
 endif
 
-ifndef CL_DIR
-$(error "CL_DIR undefined. Set CL_DIR before running this makefile")
-endif
-
-# Default to overriding BSG_IP_CORES_DIR and BSG_MANYCORE_DIR and warn
-ifneq ("$(wildcard $(CL_DIR)/../../Makefile.deps)","")
 ORANGE=\033[0;33m
 NC=\033[0m
 
+CL_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+ifneq ("$(wildcard $(CL_DIR)/../../Makefile.deps)","")
+
+# Default to overriding BSG_IP_CORES_DIR and BSG_MANYCORE_DIR and warn
 ifdef BSG_IP_CORES_DIR
 $(warning $(shell echo -e "\t\n\t$(ORANGE)Overriding BSG_IP_CORES_DIR environment variable with Bladerunner defaults.$(NC)"))
+$(warning $(shell echo -e "\t\n\t$(ORANGE)BSG_IP_CORES_DIR=$(BSG_IP_CORES_DIR)$(NC)"))
 endif
 
 ifdef BSG_MANYCORE_DIR
 $(warning $(shell echo -e "\t\n\t$(ORANGE)Overriding BSG_MANYCORE_DIR environment variable with Bladerunner defaults.$(NC)"))
+$(warning $(shell echo -e "\t\n\t$(ORANGE)BSG_MANYCORE_DIR=$(BSG_MANYCORE_DIR)$(NC)"))
 endif
 
 include $(CL_DIR)/../../Makefile.common

--- a/cl_manycore/testbenches/Makefile
+++ b/cl_manycore/testbenches/Makefile
@@ -1,3 +1,5 @@
+include ../Makefile.environment
+
 TARGETS = library spmd
 
 all: cosim

--- a/cl_manycore/testbenches/Makefile
+++ b/cl_manycore/testbenches/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.environment
-
 TARGETS = library spmd
 
 all: cosim


### PR DESCRIPTION
QoL Improvement. This allows users to run cosimulation tests from in the regression directory without setting the CL_DIR environment variable.

