### PR TITLE
Set "Ignore Cadenv" variable before building RISC-V Binaries

### DIFF
--- a/cl_manycore/regression/spmd/Makefile
+++ b/cl_manycore/regression/spmd/Makefile
@@ -7,6 +7,7 @@ $(TARGETS): test_%: $(BSG_MANYCORE_DIR)/software/spmd/%/binary
 $(BSG_MANYCORE_DIR)/software/spmd/%/binary:
 	$(MAKE) -C $(dir $@) clean main.riscv \
 		bsg_tiles_X=$(CL_MANYCORE_DIM_X) \
-		bsg_tiles_Y=$(CL_MANYCORE_DIM_Y)
+		bsg_tiles_Y=$(CL_MANYCORE_DIM_Y) \
+		IGNORE_CADENV=1
 
 

--- a/cl_manycore/testbenches/spmd/Makefile
+++ b/cl_manycore/testbenches/spmd/Makefile
@@ -1,6 +1,5 @@
 include ../../Makefile.environment
 include $(CL_DIR)/Makefile.dimensions
-
 .DEFAULT_GOAL=cosim
 
 # REGRESSION_PATH is set in Makefile.environment
@@ -15,4 +14,4 @@ include ../Makefile.common
 $(SIM_LOG_TARGETS): test_%.cosim.log: $(BSG_MANYCORE_DIR)/software/spmd/%/binary
 
 $(BSG_MANYCORE_DIR)/software/spmd/%/binary:
-	$(MAKE) -C $(TESTS_PATH) $@ 
+	$(MAKE) -C $(TESTS_PATH) $@ IGNORE_CADENV=1


### PR DESCRIPTION
* Allows users to ignore bsg_cadenv