### PR TITLE
Credits fix

### DIFF
--- a/cl_manycore/regression/library/test_manycore_credits.c
+++ b/cl_manycore/regression/library/test_manycore_credits.c
@@ -49,7 +49,7 @@ int test_manycore_credits() {
 	/* Perform an EVA write that fills DMEM of a single tile.     */
 	/**************************************************************/
 	target = hb_mc_coordinate(x, y);
-	eva = 0x0000;
+	eva = 0x1000;
 
 	for (i = 0; i < dmem_words; ++i){
 		write_data[i] = rand() % ((1 << 16)-1);
@@ -61,7 +61,7 @@ int test_manycore_credits() {
 			__func__, eva, x, y);
 		goto cleanup;
 	}
-
+	bsg_pr_info("Successfully fill DMEM of tile (%d, %d)\n", x, y);
 	rc = hb_mc_manycore_eva_read(mc, &default_map, &target, &eva, read_data, dmem_size);
 				
 	if (rc != HB_MC_SUCCESS) {

--- a/hdl/s_axil_mcl_adapter.v
+++ b/hdl/s_axil_mcl_adapter.v
@@ -7,7 +7,7 @@
 `include "bsg_axi_bus_pkg.vh"
 
 module s_axil_mcl_adapter #(
-   mcl_width_p = "inv"
+  mcl_width_p = "inv"
   ,max_out_credits_p = "inv"
   ,axil_mosi_bus_width_lp = `bsg_axil_mosi_bus_width(1)
   ,axil_miso_bus_width_lp = `bsg_axil_miso_bus_width(1)
@@ -272,7 +272,7 @@ bsg_counter_up_down #(
 
 bsg_fifo_1r1w_small #(
   .width_p           (mcl_width_p      )
-  ,.els_p             (256)
+  ,.els_p             (max_out_credits_p)
   ,.ready_THEN_valid_p(0                )
 ) rcv_fifo_converter (
   .clk_i  (clk_i           )


### PR DESCRIPTION
- The manycore link hardware now checks the receive fifo credits. If the credits are exhausted, host request write will fail.
- Fix the mismatch between the credits counter and the receive fifo elements.
