### PR TITLE
Binary loader that accepts buffer instead of path to binary

### DIFF
--- a/cl_manycore/libraries/bsg_manycore_cuda.cpp
+++ b/cl_manycore/libraries/bsg_manycore_cuda.cpp
@@ -4,13 +4,18 @@
 #include <bsg_manycore_memory_manager.h>
 #include <bsg_manycore_elf.h>
 #include <bsg_manycore_mem.h>
-#include <bsg_manycore_loader_dep.h>
 #include <bsg_manycore_loader.h>
 #include <bsg_manycore.h>
 #include <bsg_manycore_printing.h>
 #include <bsg_manycore_eva.h>
 #include <bsg_manycore_origin_eva_map.h>
 
+
+#ifdef __cplusplus
+#include <cstring>
+#else
+#include <string.h>
+#endif
 
 
 static hb_mc_epa_t hb_mc_tile_group_get_finish_signal_addr(hb_mc_tile_group_t *tg);  
@@ -726,31 +731,13 @@ int hb_mc_device_init (	hb_mc_device_t *device,
 
 
 /**
- * Freezes tiles, loads program binary into all tiles and into dram,
- * and set the symbols and registers for each tile.
+ * Loads the binary in a device's hb_mc_program_t struct
+ * onto all tiles in device's hb_mc_mesh_t struct. 
  * @param[in]  device        Pointer to device
- * @parma[in]  bin_name      Name of binary elf file
- * @param[in]  id            Id of program's meomry allocator
- * @param[in]  alloc_name    Unique name of program's memory allocator
  * @return HB_MC_SUCCESS on success and HB_MC_FAIL on failure. 
  */
-int hb_mc_device_program_init (	hb_mc_device_t *device,
-				char *bin_name,
-				const char *alloc_name,
-				hb_mc_allocator_id_t id) {
-	int error;
-	
-	device->program = (hb_mc_program_t *) malloc (sizeof (hb_mc_program_t));
-	if (device->program == NULL) { 
-		bsg_pr_err("%s: failed to allocate space on host for device hb_mc_program_t struct.\n", __func__);
-		return HB_MC_NOMEM;
-	}
-
-	device->program->bin_name = strdup (bin_name);
-	if (!device->program->bin_name) { 
-		bsg_pr_err("%s: failed to copy binary name into program struct.\n", __func__); 
-		return HB_MC_NOMEM;
-	}
+int hb_mc_device_program_load (hb_mc_device_t *device) { 
+	int error; 
 
 	uint32_t num_tiles = hb_mc_dimension_to_length (device->mesh->dim);
 
@@ -767,17 +754,7 @@ int hb_mc_device_program_init (	hb_mc_device_t *device,
 	}
 
 
-
 	// Load binary into all tiles 
-	error = hb_mc_loader_read_program_file (device->program->bin_name,
-						&(device->program->bin),
-						&(device->program->bin_size));
-	if (error != HB_MC_SUCCESS) { 
-		bsg_pr_err ("%s: failed to read binary file.\n", __func__); 
-		return error;
-	}
-	
-
 	hb_mc_coordinate_t *tile_list = (hb_mc_coordinate_t *) malloc (num_tiles * sizeof (hb_mc_coordinate_t)); 
 	for (int tile_id = 0; tile_id < num_tiles; tile_id ++) {
 		tile_list[tile_id] = device->mesh->tiles[tile_id].coord;
@@ -796,15 +773,6 @@ int hb_mc_device_program_init (	hb_mc_device_t *device,
 	}	
 
 	free (tile_list); 
-	
-
-	// Initialize program's memory allocator
-	const hb_mc_config_t *cfg = hb_mc_manycore_get_config(device->mc); 
-	error = hb_mc_program_allocator_init (cfg, device->program, alloc_name, id); 
-	if (error != HB_MC_SUCCESS) { 
-		bsg_pr_err("%s: failed to initialize memory allocator for program %s.\n", __func__, device->program->bin_name); 
-		return HB_MC_UNINITIALIZED;
-	}
 
 
 	for (int tile_id = 0; tile_id < num_tiles; tile_id++) { /* initialize tiles */
@@ -911,6 +879,64 @@ int hb_mc_device_program_init (	hb_mc_device_t *device,
 			return error;
 		}
 	}
+
+	return HB_MC_SUCCESS;
+}
+
+
+
+
+/**
+ * Freezes tiles, loads program binary into all tiles and into dram,
+ * and set the symbols and registers for each tile.
+ * @param[in]  device        Pointer to device
+ * @parma[in]  bin_name      Name of binary elf file
+ * @param[in]  id            Id of program's meomry allocator
+ * @param[in]  alloc_name    Unique name of program's memory allocator
+ * @return HB_MC_SUCCESS on success and HB_MC_FAIL on failure. 
+ */
+int hb_mc_device_program_init (	hb_mc_device_t *device,
+				char *bin_name,
+				const char *alloc_name,
+				hb_mc_allocator_id_t id) {
+	int error;
+	
+	device->program = (hb_mc_program_t *) malloc (sizeof (hb_mc_program_t));
+	if (device->program == NULL) { 
+		bsg_pr_err("%s: failed to allocate space on host for device hb_mc_program_t struct.\n", __func__);
+		return HB_MC_NOMEM;
+	}
+
+	device->program->bin_name = strdup (bin_name);
+	if (!device->program->bin_name) { 
+		bsg_pr_err("%s: failed to copy binary name into program struct.\n", __func__); 
+		return HB_MC_NOMEM;
+	}
+
+	// Load binary from file into buffer
+	error = hb_mc_loader_read_program_file (device->program->bin_name,
+						&(device->program->bin),
+						&(device->program->bin_size));
+	if (error != HB_MC_SUCCESS) { 
+		bsg_pr_err ("%s: failed to read binary file.\n", __func__); 
+		return error;
+	}
+
+	// Initialize program's memory allocator
+	const hb_mc_config_t *cfg = hb_mc_manycore_get_config(device->mc); 
+	error = hb_mc_program_allocator_init (cfg, device->program, alloc_name, id); 
+	if (error != HB_MC_SUCCESS) { 
+		bsg_pr_err("%s: failed to initialize memory allocator for program %s.\n", __func__, device->program->bin_name); 
+		return HB_MC_UNINITIALIZED;
+	}
+
+	// Load binary onto all tiles
+	error = hb_mc_device_program_load (device); 
+	if (error != HB_MC_SUCCESS) { 
+		bsg_pr_err("%s: failed to load program binary onto device tiles.\n", __func__);
+		return error;
+	}
+
 	return HB_MC_SUCCESS;
 }
 

--- a/cl_manycore/libraries/bsg_manycore_cuda.h
+++ b/cl_manycore/libraries/bsg_manycore_cuda.h
@@ -139,8 +139,36 @@ int hb_mc_device_program_load (hb_mc_device_t *device);
 
 
 
+
+
 /**
- * Initializes Manycore tiles so that they may run kernels.
+ * Takes in a buffer containing the binary and its size,
+ * freezes tiles, loads program binary into all tiles and into dram,
+ * and sets the symbols and registers for each tile.
+ * @param[in]  device        Pointer to device
+ * @parma[in]  bin_name      Name of binary elf file
+ * @param[in]  bin_data      Buffer containing binary 
+ * @param[in]  bin_size      Size of the binary to be loaded onto device
+ * @param[in]  id            Id of program's memory allocator
+ * @param[in]  alloc_name    Unique name of program's memory allocator
+ * @return HB_MC_SUCCESS on success and HB_MC_FAIL on failure.
+ */
+__attribute__((warn_unused_result))
+int hb_mc_device_program_init_binary  (	hb_mc_device_t *device,
+					char *bin_name,
+					char *bin_data,
+					size_t bin_size,
+					const char *alloc_name,
+					hb_mc_allocator_id_t id);
+
+
+
+
+
+/**
+ * Takes in a binary name, loads the binary from file onto a buffer,
+ * freezes tiles, loads program binary into all tiles and into dram,
+ * and sets the symbols and registers for each tile.
  * @param[in]  device        Pointer to device
  * @parma[in]  bin_name      Name of binary elf file
  * @param[in]  id            Id of program's memory allocator

--- a/cl_manycore/libraries/bsg_manycore_cuda.h
+++ b/cl_manycore/libraries/bsg_manycore_cuda.h
@@ -126,6 +126,19 @@ int hb_mc_device_init (	hb_mc_device_t *device,
 
 
 
+
+/**
+ * Loads the binary in a device's hb_mc_program_t struct onto
+ * all tiles in the device's hb_mc_mesh_t struct.
+ * device struct with list of all tiles and their cooridnates 
+ * @param[in]  device        Pointer to device
+ * @return HB_MC_SUCCESS on success and HB_MC_FAIL on failure. 
+ */
+int hb_mc_device_program_load (hb_mc_device_t *device);
+
+
+
+
 /**
  * Initializes Manycore tiles so that they may run kernels.
  * @param[in]  device        Pointer to device


### PR DESCRIPTION
This pull request addresses issue #92 .
Now users can either call hb_mc_device_program_init that takes in path to binary and automatically loads into a buffer, or call hb_mc_device_program_init_binary with a prepared buffer that contains the binary and binary size. 

hb_mc_device_program_init is separated into three functions: 
1. hb_mc_device_program_init(): load binary from file into buffer and call 2
2. hb_mc_device_program_init_binary(): copy binary buffer and set all variables in device's program_t struct and call 3
3. hb_mc_device_program_load(): loads the binary onto all tiles and unfreezes them.

Cuda regression tests passed, ready to merge. 