### PR TITLE
Added functions to Parse runtime variables from elf file in CUDA API 

### DIFF
--- a/cl_manycore/libraries/bsg_manycore_cuda.h
+++ b/cl_manycore/libraries/bsg_manycore_cuda.h
@@ -565,6 +565,53 @@ int hb_mc_tile_set_grid_dim_symbols(	hb_mc_manycore_t *mc,
 
 
 
+
+int hb_mc_tile_set_kernel_ptr_symbol(	hb_mc_manycore_t *mc,
+					hb_mc_eva_map_t *map,
+					unsigned char* bin,
+					size_t bin_size,
+					const hb_mc_coordinate_t *coord,
+					const hb_mc_eva_t *kernel_eva);
+
+
+
+
+
+
+int hb_mc_tile_set_argc_symbol	(	hb_mc_manycore_t *mc,
+					hb_mc_eva_map_t *map,
+					unsigned char* bin,
+					size_t bin_size,
+					const hb_mc_coordinate_t *coord,
+					const uint32_t *argc);
+
+
+
+
+
+
+int hb_mc_tile_set_argv_ptr_symbol(	hb_mc_manycore_t *mc,
+					hb_mc_eva_map_t *map,
+					unsigned char* bin,
+					size_t bin_size,
+					const hb_mc_coordinate_t *coord,
+					const hb_mc_eva_t *argv_eva);
+
+
+
+
+
+int hb_mc_tile_set_finish_signal_addr_symbol(	hb_mc_manycore_t *mc,
+						hb_mc_eva_map_t *map,
+						unsigned char* bin,
+						size_t bin_size,
+						const hb_mc_coordinate_t *coord,
+						const hb_mc_eva_t *finish_signal_addr_eva);
+
+
+
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/cl_manycore/libraries/bsg_manycore_cuda.h
+++ b/cl_manycore/libraries/bsg_manycore_cuda.h
@@ -16,16 +16,6 @@ extern "C" {
 #endif
 
 
-// Base EPA of all parameters for cuda lite runtime software
-#define HB_MC_CUDA_TILE_PARAMETERS_BASE_EPA	0x1100
-// EPA of pointer to kernel binary in tile. 
-#define HB_MC_CUDA_TILE_KERNEL_PTR_EPA		(HB_MC_CUDA_TILE_PARAMETERS_BASE_EPA + 0x0000)
-// EPA of argument count of kernel in tile.
-#define HB_MC_CUDA_TILE_ARGC_PTR_EPA		(HB_MC_CUDA_TILE_PARAMETERS_BASE_EPA + 0x0004)  
-// EPA of pointer to argument list of kernel in tile.
-#define HB_MC_CUDA_TILE_ARGV_PTR_EPA		(HB_MC_CUDA_TILE_PARAMETERS_BASE_EPA + 0x0008)
-// EPA of finish signal memory location in tile.
-#define HB_MC_CUDA_TILE_FINISH_SIGNAL_PTR_EPA	(HB_MC_CUDA_TILE_PARAMETERS_BASE_EPA + 0x000C)  
 // Kernel is not loaded into tile if kernel poitner equals this value.
 #define HB_MC_CUDA_KERNEL_NOT_LOADED		0x0001	
 // The begining of section in host memory intended for tile groups to write finish signals into
@@ -410,12 +400,14 @@ int hb_mc_device_tiles_freeze(	hb_mc_device_t *device,
 /**
  * Sends packets to all tiles in the list to set their kernel pointer to 1 and unfreeze them
  * @param[in]  device        Pointer to device
+ * @param[in]  map           EVA to NPA mapping for the tiles
  * @param[in]  tiles         List of tile coordinates to unfreeze
  * @param[in]  num_tiles     Number of tiles in the list
  * @return HB_MC_SUCCESS if succesful. Otherwise an error code is returned.
  */
 __attribute__((warn_unused_result))
 int hb_mc_device_tiles_unfreeze(	hb_mc_device_t *device,
+					hb_mc_eva_map_t *map,
 					hb_mc_coordinate_t *tiles,
 					uint32_t num_tiles);
 

--- a/cl_manycore/libraries/bsg_manycore_cuda.h
+++ b/cl_manycore/libraries/bsg_manycore_cuda.h
@@ -418,33 +418,6 @@ int hb_mc_device_tiles_unfreeze(	hb_mc_device_t *device,
 
 
 
-/**
- * Sends packets to all tiles in the list to set their configuration symbols in the binary
- * @param[in]  device        Pointer to devicei
- * @param[in]  map           EVA to NPA mapping for tiles
- * @param[in]  origin        Origin coordinates of the tiles in the list
- * @param[in]  tg_id         Tile group id of the tiles in the list
- * @param[in]  tg_dim        Tile group dimensions of the tiles in the list
- * @param[in]  grid_dim      Grid dimensions of the tiles in the list
- * @param[in]  tiles         List of tile coordinates to unfreeze
- * @param[in]  num_tiles     Number of tiles in the list
- * @return HB_MC_SUCCESS if succesful. Otherwise an error code is returned.
- */
-__attribute__((warn_unused_result))
-int hb_mc_device_tiles_set_symbols(	hb_mc_device_t *device, 
-					hb_mc_eva_map_t *map,
-					hb_mc_coordinate_t origin,
-					hb_mc_coordinate_t tg_id,
-					hb_mc_dimension_t tg_dim,
-					hb_mc_dimension_t grid_dim,
-					hb_mc_coordinate_t *tiles,
-					uint32_t num_tiles);
-
-
-
-
-
-
 #ifdef __cplusplus
 }
 #endif

--- a/cl_manycore/libraries/bsg_manycore_cuda.h
+++ b/cl_manycore/libraries/bsg_manycore_cuda.h
@@ -17,9 +17,12 @@ extern "C" {
 
 
 // Kernel is not loaded into tile if kernel poitner equals this value.
-#define HB_MC_CUDA_KERNEL_NOT_LOADED		0x0001	
-// The begining of section in host memory intended for tile groups to write finish signals into
+#define HB_MC_CUDA_KERNEL_NOT_LOADED_VAL	0x0001
+// The value that is written on to finish_signal_addr to show that tile group execution is done.
+#define HB_MC_CUDA_FINISH_SIGNAL_VAL		0x0001	
+// The begining of section in host memory intended for tile groups to write finish signals into.
 #define HB_MC_CUDA_HOST_FINISH_SIGNAL_BASE_ADDR	0xF000	
+
 
 
 typedef uint8_t tile_group_id_t;
@@ -437,168 +440,6 @@ int hb_mc_device_tiles_set_symbols(	hb_mc_device_t *device,
 					hb_mc_coordinate_t *tiles,
 					uint32_t num_tiles);
 
-
-
-
-/*!
- * Sets a Vanilla Core Endpoint's tile group's origin symbols __bsg_grp_org_x/y.
- * Behavior is undefined if #mc is not initialized with hb_mc_manycore_init().
- * @param[in] mc         A manycore instance initialized with hb_mc_manycore_init().
- * @param[in] map        Eva to npa mapping. 
- * @param[in] bin        Binary elf file.
- * @param[in] bin_size   Size of binary file. 
- * @param[in] coord      Tile coordinates to set the origin of.
- * @param[in] origin     Origin coordinates.
- * @return HB_MC_SUCCESS if succesful. Otherwise an error code is returned.
- */
-__attribute__((warn_unused_result))
-int hb_mc_tile_set_origin_symbols(	hb_mc_manycore_t *mc,
-					hb_mc_eva_map_t *map,
-					unsigned char *bin,
-					size_t bin_size,
-					const hb_mc_coordinate_t *coord,
-					const hb_mc_coordinate_t *origin);
-
-
-
-
-
-/*!
- * Sets a Vanilla Core Endpoint's tile group's coordinate symbols __bsg_x/y.
- * Behavior is undefined if #mc is not initialized with hb_mc_manycore_init().
- * @param[in] mc         A manycore instance initialized with hb_mc_manycore_init().
- * @param[in] map        Eva to npa mapping. 
- * @param[in] bin        Binary elf file. 
- * @param[in] bin_size   Size of binary file. 
- * @param[in] coord      Tile coordinates to set the coordinates of.
- * @param[in] coord_val  The coordinates to set the tile.
- * @return HB_MC_SUCCESS if succesful. Otherwise an error code is returned.
- */
-__attribute__((warn_unused_result))
-int hb_mc_tile_set_coord_symbols(	hb_mc_manycore_t *mc,
-					hb_mc_eva_map_t *map,
-					unsigned char* bin,
-					size_t bin_size,
-					const hb_mc_coordinate_t *coord,
-					const hb_mc_coordinate_t *coord_val);
-
-
-
-
-
-/*! 
- * Sets a Vanilla Core Endpoint's tile's __bsg_id symbol.
- * Behavior is undefined if #mc is not initialized with hb_mc_manycore_init().
- * @param[in] mc         A manycore instance initialized with hb_mc_manycore_init().
- * @param[in] map        Eva to npa mapping. 
- * @param[in] bin        Binary elf file. 
- * @param[in] bin_size   Size of binary file. 
- * @param[in] coord      Tile coordinates to set the id of.
- * @param[in] coord_val  The coordinates to set the tile.
- * @param[in] dim        Tile group dimensions
- * @return HB_MC_SUCCESS if succesful. Otherwise an error code is returned.
- */
-__attribute__((warn_unused_result))
-int hb_mc_tile_set_id_symbol(	hb_mc_manycore_t *mc,
-				hb_mc_eva_map_t *map,
-				unsigned char* bin,
-				size_t bin_size,
-				const hb_mc_coordinate_t *coord,
-				const hb_mc_coordinate_t *coord_val,
-				const hb_mc_dimension_t *dim);
-
-
-
-
-
-/*! 
- * Sets a Vanilla Core Endpoint's tile's __bsg_tile_group_id_x/y symbol.
- * Behavior is undefined if #mc is not initialized with hb_mc_manycore_init().
- * @param[in] mc         A manycore instance initialized with hb_mc_manycore_init().
- * @param[in] map        Eva to npa mapping. 
- * @param[in] bin        Binary elf file. 
- * @param[in] bin_size   Size of binary file. 
- * @param[in] coord      Tile coordinates to set the tile group id of.
- * @param[in] tg_id      Tile group id
- * @return HB_MC_SUCCESS if succesful. Otherwise an error code is returned.
- */
-__attribute__((warn_unused_result))
-int hb_mc_tile_set_tile_group_id_symbols(	hb_mc_manycore_t *mc,
-						hb_mc_eva_map_t *map,
-						unsigned char* bin,
-						size_t bin_size,
-						const hb_mc_coordinate_t *coord,
-						const hb_mc_coordinate_t *tg_id);
-
-
-
-
-
-/*! 
- * Sets a Vanilla Core Endpoint's tile's __bsg_grid_dim_x/y symbol.
- * Behavior is undefined if #mc is not initialized with hb_mc_manycore_init().
- * @param[in] mc         A manycore instance initialized with hb_mc_manycore_init().
- * @param[in] map        Eva to npa mapping. 
- * @param[in] bin        Binary elf file. 
- * @param[in] bin_size   Size of binary file. 
- * @param[in] coord      Tile coordinates to set the tile group id of.
- * @param[in] tg_id      Grid dimensions
- * @return HB_MC_SUCCESS if succesful. Otherwise an error code is returned.
- */
-__attribute__((warn_unused_result))
-int hb_mc_tile_set_grid_dim_symbols(	hb_mc_manycore_t *mc,
-					hb_mc_eva_map_t *map,
-					unsigned char* bin,
-					size_t bin_size,
-					const hb_mc_coordinate_t *coord,
-					const hb_mc_dimension_t *grid_dim);
-
-
-
-
-
-
-int hb_mc_tile_set_kernel_ptr_symbol(	hb_mc_manycore_t *mc,
-					hb_mc_eva_map_t *map,
-					unsigned char* bin,
-					size_t bin_size,
-					const hb_mc_coordinate_t *coord,
-					const hb_mc_eva_t *kernel_eva);
-
-
-
-
-
-
-int hb_mc_tile_set_argc_symbol	(	hb_mc_manycore_t *mc,
-					hb_mc_eva_map_t *map,
-					unsigned char* bin,
-					size_t bin_size,
-					const hb_mc_coordinate_t *coord,
-					const uint32_t *argc);
-
-
-
-
-
-
-int hb_mc_tile_set_argv_ptr_symbol(	hb_mc_manycore_t *mc,
-					hb_mc_eva_map_t *map,
-					unsigned char* bin,
-					size_t bin_size,
-					const hb_mc_coordinate_t *coord,
-					const hb_mc_eva_t *argv_eva);
-
-
-
-
-
-int hb_mc_tile_set_finish_signal_addr_symbol(	hb_mc_manycore_t *mc,
-						hb_mc_eva_map_t *map,
-						unsigned char* bin,
-						size_t bin_size,
-						const hb_mc_coordinate_t *coord,
-						const hb_mc_eva_t *finish_signal_addr_eva);
 
 
 

--- a/cl_manycore/regression/cuda/Makefile.tests
+++ b/cl_manycore/regression/cuda/Makefile.tests
@@ -2,7 +2,8 @@ INDEPENDENT_MAIN_TESTS_TYPE = cuda
 
 UNIFIED_MAIN_TESTS = 
 # For F1, only run one test at a time, and reload the agfi image in between runs. To be fixed.
-INDEPENDENT_MAIN_TESTS = test_multiple_binary_load
+INDEPENDENT_MAIN_TESTS = test_empty
+INDEPENDENT_MAIN_TESTS += test_multiple_binary_load
 
 #INDEPENDENT_MAIN_TESTS = test_empty 
 #INDEPENDENT_MAIN_TESTS += test_empty_parallel 


### PR DESCRIPTION
This PR addresses issue #175 . 
Introduced 6 new symbols in the cuda_lite_runtime code , cuda_kernel_ptr, cuda_argc, cuda_argv_ptr, cuda_finish_signal_addrl, cuda_finish_signal_val and cuda_kernel_not_loaded_val. The symbols are set by the CUDA API after binary is loaded onto tiles. 
Added the following functions: 
hb_mc_tiles_set_runtime_symbols --> Calls all functions below:
    - hb_mc_tile_set_kernel_ptr_symbol
    - hb_mc_tile_set_argc_symbol
    - hb_mc_tile_set_argv_ptr_symbol
    - hb_mc_tile_set_finish_signal_addr_symbol

Changed hb_mc_tiles_set_symbols to hb_mc_tiles_set_config_symbols which also calls two new functions: 
    - hb_mc_tile_set_finish_signal_val
    - hb_mc_tile_set_kernel_not_loaded_val 

Regression tests passed (F1 and cosim). 
**Should ONLY be merged in together with PR # 65 on the bsg_manycore.**
