### PR TITLE
Host API for No-DRAM Mode

### DIFF
--- a/cl_manycore/libraries/Makefile
+++ b/cl_manycore/libraries/Makefile
@@ -61,6 +61,8 @@ STRICT_OBJECTS :=
 STRICT_OBJECTS += bsg_manycore_responder.o
 STRICT_OBJECTS += bsg_manycore_loader.o
 STRICT_OBJECTS += bsg_manycore_packet_id.o
+STRICT_OBJECTS += bsg_manycore_eva.o
+STRICT_OBJECTS += bsg_manycore_origin_eva_map.o
 
 $(STRICT_OBJECTS): CXXFLAGS += -Wall -Werror
 $(STRICT_OBJECTS): CXXFLAGS += -Wno-unused-variable

--- a/cl_manycore/libraries/bsg_manycore.cpp
+++ b/cl_manycore/libraries/bsg_manycore.cpp
@@ -183,7 +183,7 @@ static int hb_mc_manycore_rx_fifo_drain(hb_mc_manycore_t *mc, hb_mc_fifo_rx_t ty
 		/* break if occupancy is zero */
 		if (occupancy == 0)
 			break;
-	
+
 		/* Read stale packets from fifo */
 		for (unsigned i = 0; i < occupancy; i++){
 			rc = hb_mc_manycore_packet_rx_internal(mc, (hb_mc_packet_t*) &recv, type, -1);
@@ -206,7 +206,7 @@ static int hb_mc_manycore_rx_fifo_drain(hb_mc_manycore_t *mc, hb_mc_fifo_rx_t ty
 					recv.data);
 		}
 	}
-	
+
         /* recheck occupancy to make sure all packets are drained. */
         rc = hb_mc_manycore_rx_fifo_get_occupancy(mc, type, &occupancy);
         if (rc != HB_MC_SUCCESS)
@@ -466,6 +466,7 @@ static int hb_mc_manycore_init_fifos(hb_mc_manycore_t *mc)
 	if (rc != HB_MC_SUCCESS)
 		return rc;
 
+        mc->dram_enabled = 1;
 
         return HB_MC_SUCCESS;
 }

--- a/cl_manycore/libraries/bsg_manycore.cpp
+++ b/cl_manycore/libraries/bsg_manycore.cpp
@@ -466,8 +466,6 @@ static int hb_mc_manycore_init_fifos(hb_mc_manycore_t *mc)
 	if (rc != HB_MC_SUCCESS)
 		return rc;
 
-        mc->dram_enabled = 1;
-
         return HB_MC_SUCCESS;
 }
 
@@ -523,6 +521,10 @@ int  hb_mc_manycore_init(hb_mc_manycore_t *mc, const char *name, hb_mc_manycore_
 
 	// initialize responders
 	if ((err = hb_mc_responders_init(mc)))
+		goto cleanup;
+
+	// enable dram
+	if ((err = hb_mc_manycore_enable_dram(mc)) != HB_MC_SUCCESS)
 		goto cleanup;
 
         r = HB_MC_SUCCESS;
@@ -1337,11 +1339,12 @@ static int hb_mc_manycore_write(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa, co
 
 	/* transmit the request */
 	manycore_pr_dbg(mc, "Sending %d-byte write request to NPA "
-			"(x: %d, y: %d, 0x%08x)\n",
+			"(x: %d, y: %d, 0x%08x) (data = 0x%08" PRIx32 ")\n",
 			sz,
 			hb_mc_npa_get_x(npa),
 			hb_mc_npa_get_y(npa),
-			hb_mc_npa_get_epa(npa));
+			hb_mc_npa_get_epa(npa),
+			hb_mc_request_packet_get_data(&rqst.request));
 
 	return hb_mc_manycore_request_tx(mc, &rqst.request, -1);
 }
@@ -1572,4 +1575,59 @@ int hb_mc_manycore_write16(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa, uint16_
 int hb_mc_manycore_write32(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa, uint32_t v)
 {
 	return hb_mc_manycore_write(mc, npa, &v, 4);
+}
+
+
+/**
+ * Enable DRAM mode on the manycore instance.
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @return One if DRAM is enabled. Zero otherwise.
+ */
+int hb_mc_manycore_enable_dram(hb_mc_manycore_t *mc)
+{
+	const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
+	/* for each tile */
+	hb_mc_idx_t
+		n_rows = hb_mc_dimension_get_y(hb_mc_config_get_dimension_vcore(cfg)),
+		n_cols = hb_mc_dimension_get_x(hb_mc_config_get_dimension_vcore(cfg));
+
+	for (hb_mc_idx_t row = 0; row < n_rows; row++) {
+		for (hb_mc_idx_t col = 0; col < n_cols; col++) {
+			hb_mc_idx_t x = col + hb_mc_config_get_vcore_base_x(cfg);
+			hb_mc_idx_t y = row + hb_mc_config_get_vcore_base_y(cfg);
+			hb_mc_coordinate_t tile = hb_mc_coordinate(x,y);
+			int err = hb_mc_tile_set_dram_enabled(mc, &tile);
+			if (err != HB_MC_SUCCESS)
+				return err;
+		}
+	}
+        mc->dram_enabled = 1;
+	return HB_MC_SUCCESS;
+}
+
+/**
+ * Disable DRAM mode on the manycore instance.
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @return One if DRAM is enabled. Zero otherwise.
+ */
+int hb_mc_manycore_disable_dram(hb_mc_manycore_t *mc)
+{
+	const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
+	/* for each tile */
+	hb_mc_idx_t
+		n_rows = hb_mc_dimension_get_y(hb_mc_config_get_dimension_vcore(cfg)),
+		n_cols = hb_mc_dimension_get_x(hb_mc_config_get_dimension_vcore(cfg));
+
+	for (hb_mc_idx_t row = 0; row < n_rows; row++) {
+		for (hb_mc_idx_t col = 0; col < n_cols; col++) {
+			hb_mc_idx_t x = col + hb_mc_config_get_vcore_base_x(cfg);
+			hb_mc_idx_t y = row + hb_mc_config_get_vcore_base_y(cfg);
+			hb_mc_coordinate_t tile = hb_mc_coordinate(x,y);
+			int err = hb_mc_tile_clear_dram_enabled(mc, &tile);
+			if (err != HB_MC_SUCCESS)
+				return err;
+		}
+	}
+        mc->dram_enabled = 0;
+	return HB_MC_SUCCESS;
 }

--- a/cl_manycore/libraries/bsg_manycore.h
+++ b/cl_manycore/libraries/bsg_manycore.h
@@ -29,6 +29,7 @@ typedef struct hb_mc_manycore {
         hb_mc_config_t config;   //!< configuration of the manycore
         void    *private_data;   //!< implementation private data
 	unsigned htod_requests;  //!< outstanding host requests
+        int dram_enabled;        //!< operating in no-dram mode?
 } hb_mc_manycore_t;
 
 #define HB_MC_MANYCORE_INIT {0}
@@ -305,10 +306,6 @@ int hb_mc_manycore_mmio_write32(hb_mc_manycore_t *mc, uintptr_t offset, uint32_t
 // Address Translation API //
 /////////////////////////////
 
-#ifndef HB_MC_NO_DRAM_MODE
-#define HB_MC_NO_DRAM_MODE (0)
-#endif
-
 /**
  * Query if we are operating in no DRAM mode.
  * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
@@ -318,7 +315,27 @@ static inline int hb_mc_manycore_dram_is_enabled(const hb_mc_manycore_t *mc)
 {
 	// at the moment we set this at compile time
 	// TODO: maybe make this a runtime setting
-	return HB_MC_NO_DRAM_MODE ? 0 : 1;
+	return mc->dram_enabled;
+}
+
+/**
+ * Enable DRAM mode on the manycore instance.
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @return One if DRAM is enabled. Zero otherwise.
+ */
+static inline void hb_mc_manycore_enable_dram(hb_mc_manycore_t *mc)
+{
+        mc->dram_enabled = 1;
+}
+
+/**
+ * Disable DRAM mode on the manycore instance.
+ * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
+ * @return One if DRAM is enabled. Zero otherwise.
+ */
+static inline void hb_mc_manycore_disable_dram(hb_mc_manycore_t *mc)
+{
+        mc->dram_enabled = 0;
 }
 
 /**

--- a/cl_manycore/libraries/bsg_manycore.h
+++ b/cl_manycore/libraries/bsg_manycore.h
@@ -323,20 +323,14 @@ static inline int hb_mc_manycore_dram_is_enabled(const hb_mc_manycore_t *mc)
  * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
  * @return One if DRAM is enabled. Zero otherwise.
  */
-static inline void hb_mc_manycore_enable_dram(hb_mc_manycore_t *mc)
-{
-        mc->dram_enabled = 1;
-}
+int hb_mc_manycore_enable_dram(hb_mc_manycore_t *mc);
 
 /**
  * Disable DRAM mode on the manycore instance.
  * @param[in]  mc     A manycore instance initialized with hb_mc_manycore_init()
  * @return One if DRAM is enabled. Zero otherwise.
  */
-static inline void hb_mc_manycore_disable_dram(hb_mc_manycore_t *mc)
-{
-        mc->dram_enabled = 0;
-}
+int hb_mc_manycore_disable_dram(hb_mc_manycore_t *mc);
 
 /**
  * Get a pointer to the configuration struct

--- a/cl_manycore/libraries/bsg_manycore_config.h
+++ b/cl_manycore/libraries/bsg_manycore_config.h
@@ -288,6 +288,18 @@ static inline uint32_t hb_mc_config_get_vcache_block_size(const hb_mc_config_t *
         return cfg->vcache_block_words * sizeof(uint32_t); // words are four bytes
 }
 
+/**
+ * Return the number of bytes in a victim cache block.
+ * @param[in] cfg A configuration initialized from the manycore ROM.
+ * @return the number of words in a victim cache block.
+ */
+static inline uint32_t hb_mc_config_get_vcache_size(const hb_mc_config_t *cfg)
+{
+	return hb_mc_config_get_vcache_block_size(cfg) *
+		hb_mc_config_get_vcache_sets(cfg) *
+		hb_mc_config_get_vcache_ways(cfg);
+}
+
 
 #ifdef __cplusplus
 }

--- a/cl_manycore/libraries/bsg_manycore_config.h
+++ b/cl_manycore/libraries/bsg_manycore_config.h
@@ -278,6 +278,17 @@ static inline uint32_t hb_mc_config_get_vcache_block_words(const hb_mc_config_t 
         return cfg->vcache_block_words;
 }
 
+/**
+ * Return the number of bytes in a victim cache block.
+ * @param[in] cfg A configuration initialized from the manycore ROM.
+ * @return the number of words in a victim cache block.
+ */
+static inline uint32_t hb_mc_config_get_vcache_block_size(const hb_mc_config_t *cfg)
+{
+        return cfg->vcache_block_words * sizeof(uint32_t); // words are four bytes
+}
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/cl_manycore/libraries/bsg_manycore_cuda.cpp
+++ b/cl_manycore/libraries/bsg_manycore_cuda.cpp
@@ -1661,6 +1661,7 @@ static int hb_mc_device_tiles_set_config_symbols (	hb_mc_device_t *device,
 			return error;
 		}
 
+
 		error = hb_mc_tile_set_symbol_val(	device->mc,
 							map,
 							device->program->bin,
@@ -1785,23 +1786,9 @@ static int hb_mc_device_tiles_set_runtime_symbols (	hb_mc_device_t *device,
 	int error;
 	const hb_mc_config_t *cfg = hb_mc_manycore_get_config (device->mc); 
 
+
 	for (hb_mc_idx_t tile_id = 0; tile_id < num_tiles; tile_id ++) { 
 
-		// Set tile's argument count cuda_argc symbol.
-		error = hb_mc_tile_set_symbol_val(	device->mc,
-							map,
-							device->program->bin,
-							device->program->bin_size,
-							&(tiles[tile_id]),
-							"cuda_argc",
-							&argc);
-		if (error != HB_MC_SUCCESS) { 
-			bsg_pr_err(	"%s: failed to set tile (%d,%d) cuda_argc symbol.\n",
-					__func__,
-					hb_mc_coordinate_get_x(tiles[tile_id]),
-					hb_mc_coordinate_get_y(tiles[tile_id]));
-			return error;
-		}
 
 		// Set tile's argument count cuda_argc symbol.
 		error = hb_mc_tile_set_symbol_val(	device->mc,
@@ -1821,21 +1808,6 @@ static int hb_mc_device_tiles_set_runtime_symbols (	hb_mc_device_t *device,
 
 
 
-		// Set tile's pointer to argument list cuda_argv_ptr symbol.
-		error = hb_mc_tile_set_symbol_val(	device->mc,
-							map,
-							device->program->bin,
-							device->program->bin_size,
-							&(tiles[tile_id]),
-							"cuda_argv_ptr",
-							&args_eva);
-		if (error != HB_MC_SUCCESS) { 
-			bsg_pr_err(	"%s: failed to set tile (%d,%d) cuda_argv_ptr symbol.\n",
-					__func__,
-					hb_mc_coordinate_get_x(tiles[tile_id]),
-					hb_mc_coordinate_get_y(tiles[tile_id]));
-			return error;
-		}
 
 		// Set tile's pointer to argument list cuda_argv_ptr symbol.
 		error = hb_mc_tile_set_symbol_val(	device->mc,
@@ -1860,7 +1832,7 @@ static int hb_mc_device_tiles_set_runtime_symbols (	hb_mc_device_t *device,
 		// Calculate the eva address to which the tile is supposed to send it's finish signal
 		hb_mc_eva_t finish_signal_eva;
 		size_t sz; 
-		error = hb_mc_npa_to_eva (cfg, map, &(tiles[tile_id]), &(finish_signal_npa), &finish_signal_eva, &sz); 
+		error = hb_mc_npa_to_eva (device->mc, map, &(tiles[tile_id]), &(finish_signal_npa), &finish_signal_eva, &sz); 
 		if (error != HB_MC_SUCCESS) { 
 			bsg_pr_err("%s: failed to acquire finish signal address eva from npa.\n", __func__); 
 			return error;

--- a/cl_manycore/libraries/bsg_manycore_cuda.cpp
+++ b/cl_manycore/libraries/bsg_manycore_cuda.cpp
@@ -606,70 +606,23 @@ int hb_mc_tile_group_launch (hb_mc_device_t *device, hb_mc_tile_group_t *tg) {
 	}
 	
 
-			tile_id = hb_mc_get_tile_id (device->mesh->origin, device->mesh->dim, hb_mc_coordinate(x, y)); 
-
-
-			hb_mc_npa_t argc_ptr_npa = hb_mc_npa (device->mesh->tiles[tile_id].coord, HB_MC_CUDA_TILE_ARGC_PTR_EPA); 
-			error = hb_mc_manycore_write32(device->mc, &argc_ptr_npa, tg->kernel->argc);
-			if (error != HB_MC_SUCCESS) { 
-				bsg_pr_err(	"%s: failed to write argc to tile (%d,%d) for grid %d tile group (%d,%d).\n",
-						__func__,
-						hb_mc_coordinate_get_x(device->mesh->tiles[tile_id].coord),
-						hb_mc_coordinate_get_y(device->mesh->tiles[tile_id].coord),
-						tg->grid_id,
-						hb_mc_coordinate_get_x(tg->id), hb_mc_coordinate_get_y(tg->id));
-				return error;
-			}
-			bsg_pr_dbg(	"%s: Setting tile[%d] (%d,%d) argc to %d.\n",
-					__func__,
-					tile_id,
-					x, y,
-					tg->kernel->argc);
-
-			hb_mc_npa_t argv_ptr_npa = hb_mc_npa (device->mesh->tiles[tile_id].coord, HB_MC_CUDA_TILE_ARGV_PTR_EPA); 
-			error = hb_mc_manycore_write32(device->mc, &argv_ptr_npa, args_eva);	
-			if (error != HB_MC_SUCCESS) { 
-				bsg_pr_err(	"%s: failed to write argv pointer to tile (%d,%d) for grid %d tile group (%d,%d).\n",
-						__func__,
-						hb_mc_coordinate_get_x(device->mesh->tiles[tile_id].coord),
-						hb_mc_coordinate_get_y(device->mesh->tiles[tile_id].coord),
-						tg->grid_id, hb_mc_coordinate_get_x(tg->id),
-						hb_mc_coordinate_get_y(tg->id));
-				return error;
-			}
-			bsg_pr_dbg(	"%s: Setting tile[%d] (%d,%d) argv to 0x%08" PRIx32 ".\n",
-					__func__,
-					tile_id,
-					x, y,
-					args_eva);
-
-
-			hb_mc_eva_t finish_signal_eva;
-			size_t sz; 
-			error = hb_mc_npa_to_eva (device->mc, tg->map, &(device->mesh->tiles[tile_id].coord), &(finish_signal_npa), &finish_signal_eva, &sz);
-			if (error != HB_MC_SUCCESS) { 
-				bsg_pr_err("%s: failed to acquire finish signal address eva from npa.\n", __func__); 
-				return error;
-			}
-
-
-			hb_mc_npa_t finish_signal_ptr_npa = hb_mc_npa (device->mesh->tiles[tile_id].coord, HB_MC_CUDA_TILE_FINISH_SIGNAL_PTR_EPA);
-			error = hb_mc_manycore_write32(device->mc, &finish_signal_ptr_npa, finish_signal_eva); 
-			if (error != HB_MC_SUCCESS) {
-				bsg_pr_err(	"%s: failed to write finish signal address to tile (%d,%d) for grid %d tile group (%d,%d).\n",
-						__func__,
-						hb_mc_coordinate_get_x(device->mesh->tiles[tile_id].coord),
-						hb_mc_coordinate_get_y(device->mesh->tiles[tile_id].coord),
-						tg->grid_id,
-						hb_mc_coordinate_get_x(tg->id),
-						hb_mc_coordinate_get_y(tg->id));
-				return error;
-			}
-			bsg_pr_dbg(	"%s: Setting tile[%d] (%d,%d) HB_MC_CUDA_TILE_FINISH_SIGNAL_PTR_EPA to 0x%08" PRIx32 ".\n",
-					__func__,
-					tile_id,
-					x, y,
-					finish_signal_eva);
+	// Set the runtime symbols of all tiles inside tile group
+	error = hb_mc_device_tiles_set_runtime_symbols(	device,
+							tg->map,
+							tg->kernel->argc,
+							args_eva,
+							finish_signal_npa, 
+							kernel_eva,
+							tile_list,
+							num_tiles);
+	if (error != HB_MC_SUCCESS) { 
+		bsg_pr_err("%s: failed to set grid %d tile group (%d,%d) tiles runtime symbols.\n", 
+				__func__,
+				tg->grid_id,
+				hb_mc_coordinate_get_x (tg->id),
+				hb_mc_coordinate_get_y (tg->id));
+		return error;
+	}
 
 
 
@@ -1708,7 +1661,6 @@ static int hb_mc_device_tiles_set_config_symbols (	hb_mc_device_t *device,
 			return error;
 		}
 
-
 		error = hb_mc_tile_set_symbol_val(	device->mc,
 							map,
 							device->program->bin,
@@ -1833,9 +1785,23 @@ static int hb_mc_device_tiles_set_runtime_symbols (	hb_mc_device_t *device,
 	int error;
 	const hb_mc_config_t *cfg = hb_mc_manycore_get_config (device->mc); 
 
-
 	for (hb_mc_idx_t tile_id = 0; tile_id < num_tiles; tile_id ++) { 
 
+		// Set tile's argument count cuda_argc symbol.
+		error = hb_mc_tile_set_symbol_val(	device->mc,
+							map,
+							device->program->bin,
+							device->program->bin_size,
+							&(tiles[tile_id]),
+							"cuda_argc",
+							&argc);
+		if (error != HB_MC_SUCCESS) { 
+			bsg_pr_err(	"%s: failed to set tile (%d,%d) cuda_argc symbol.\n",
+					__func__,
+					hb_mc_coordinate_get_x(tiles[tile_id]),
+					hb_mc_coordinate_get_y(tiles[tile_id]));
+			return error;
+		}
 
 		// Set tile's argument count cuda_argc symbol.
 		error = hb_mc_tile_set_symbol_val(	device->mc,
@@ -1855,6 +1821,21 @@ static int hb_mc_device_tiles_set_runtime_symbols (	hb_mc_device_t *device,
 
 
 
+		// Set tile's pointer to argument list cuda_argv_ptr symbol.
+		error = hb_mc_tile_set_symbol_val(	device->mc,
+							map,
+							device->program->bin,
+							device->program->bin_size,
+							&(tiles[tile_id]),
+							"cuda_argv_ptr",
+							&args_eva);
+		if (error != HB_MC_SUCCESS) { 
+			bsg_pr_err(	"%s: failed to set tile (%d,%d) cuda_argv_ptr symbol.\n",
+					__func__,
+					hb_mc_coordinate_get_x(tiles[tile_id]),
+					hb_mc_coordinate_get_y(tiles[tile_id]));
+			return error;
+		}
 
 		// Set tile's pointer to argument list cuda_argv_ptr symbol.
 		error = hb_mc_tile_set_symbol_val(	device->mc,

--- a/cl_manycore/libraries/bsg_manycore_eva.cpp
+++ b/cl_manycore/libraries/bsg_manycore_eva.cpp
@@ -274,8 +274,9 @@ static uint32_t default_get_dram_x_bitidx(const hb_mc_config_t *cfg)
 	return MAKE_MASK(xdimlog);
 }
 
-static uint32_t default_get_dram_x_shift(const hb_mc_config_t *cfg)
+static uint32_t default_get_dram_x_shift(const hb_mc_manycore_t *mc)
 {
+        const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
         return hb_mc_config_get_vcache_bitwidth_data_addr(cfg);
 }
 
@@ -290,7 +291,7 @@ static uint32_t default_get_dram_x_shift(const hb_mc_config_t *cfg)
  * @param[out] sz     The size in bytes of the NPA segment for the #eva
  * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
  */
-static int default_eva_to_npa_dram(const hb_mc_config_t *cfg,
+static int default_eva_to_npa_dram(const hb_mc_manycore_t *mc,
 				const hb_mc_coordinate_t *o,
 				const hb_mc_coordinate_t *src,
 				const hb_mc_eva_t *eva,
@@ -301,12 +302,12 @@ static int default_eva_to_npa_dram(const hb_mc_config_t *cfg,
 	hb_mc_idx_t x, y;
 	hb_mc_epa_t epa;
 	hb_mc_dimension_t dim;
-
+        const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
 	dim = hb_mc_config_get_dimension_network(cfg);
 
 	xdimlog = default_get_x_dimlog(cfg);
 	xmask   = default_get_dram_x_bitidx(cfg);
-	shift   = default_get_dram_x_shift(cfg);
+	shift   = default_get_dram_x_shift(mc);
 
 	x = (hb_mc_eva_addr(eva) >> shift) & xmask;
 	y = hb_mc_config_get_dram_y(cfg);
@@ -366,7 +367,7 @@ int default_eva_to_npa(hb_mc_manycore_t *mc,
 	origin = (const hb_mc_coordinate_t *) priv;
 
 	if(default_eva_is_dram(eva))
-		return default_eva_to_npa_dram(cfg, origin, src, eva, npa, sz);
+		return default_eva_to_npa_dram(mc, origin, src, eva, npa, sz);
 	if(default_eva_is_global(eva))
 		return default_eva_to_npa_global(cfg, origin, src, eva, npa, sz);
 	if(default_eva_is_group(eva))
@@ -510,7 +511,7 @@ static bool default_npa_is_global(const hb_mc_config_t *config,
  * @param[out] sz       The size in bytes of the EVA segment for the #npa
  * @return HB_MC_SUCCESS if succesful. HB_MC_FAIL otherwise.
  */
-static int default_npa_to_eva_dram(const hb_mc_config_t *cfg,
+static int default_npa_to_eva_dram(hb_mc_manycore_t *mc,
                                    const hb_mc_coordinate_t *origin,
                                    const hb_mc_coordinate_t *tgt,
                                    const hb_mc_npa_t *npa,
@@ -519,7 +520,7 @@ static int default_npa_to_eva_dram(const hb_mc_config_t *cfg,
 {
         // build the eva
         hb_mc_eva_t addr = 0;
-	hb_mc_eva_t xshift = default_get_dram_x_shift(cfg);
+	hb_mc_eva_t xshift = default_get_dram_x_shift(mc);
 
         addr |= hb_mc_npa_get_epa(npa); // set the byte address
         addr |= hb_mc_npa_get_x(npa) << xshift; // set the x coordinate
@@ -652,7 +653,7 @@ int default_npa_to_eva(hb_mc_manycore_t *mc,
         const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
 
         if(default_npa_is_dram(cfg, npa, tgt))
-                return default_npa_to_eva_dram(cfg, origin, tgt, npa, eva, sz);
+                return default_npa_to_eva_dram(mc, origin, tgt, npa, eva, sz);
 
         if(default_npa_is_host(cfg, npa, tgt))
                 return default_npa_to_eva_host(cfg, origin, tgt, npa, eva, sz);
@@ -688,7 +689,7 @@ int default_eva_size(
 	o = (const hb_mc_coordinate_t *) priv;
 
 	if(default_eva_is_dram(eva))
-		return default_eva_to_npa_dram(cfg, o, o, eva, &npa, sz);
+		return default_eva_to_npa_dram(mc, o, o, eva, &npa, sz);
 	if(default_eva_is_global(eva))
 		return default_eva_to_npa_global(cfg, o, o, eva, &npa, sz);
 	if(default_eva_is_group(eva))

--- a/cl_manycore/libraries/bsg_manycore_eva.cpp
+++ b/cl_manycore/libraries/bsg_manycore_eva.cpp
@@ -355,14 +355,14 @@ static int default_eva_to_npa_dram(const hb_mc_config_t *cfg,
  * @param[out] sz     The size in bytes of the NPA segment for the #eva
  * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
  */
-int default_eva_to_npa(const hb_mc_config_t *cfg,
-		const void *priv,
-		const hb_mc_coordinate_t *src,
-		const hb_mc_eva_t *eva,
-		hb_mc_npa_t *npa, size_t *sz)
+int default_eva_to_npa(hb_mc_manycore_t *mc,
+                       const void *priv,
+                       const hb_mc_coordinate_t *src,
+                       const hb_mc_eva_t *eva,
+                       hb_mc_npa_t *npa, size_t *sz)
 {
 	const hb_mc_coordinate_t *origin;
-
+        const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
 	origin = (const hb_mc_coordinate_t *) priv;
 
 	if(default_eva_is_dram(eva))
@@ -642,13 +642,14 @@ static int default_npa_to_eva_global(const hb_mc_config_t *cfg,
  * @param[out] sz     The size in bytes of the EVA segment for the #npa
  * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
  */
-int default_npa_to_eva(const hb_mc_config_t *cfg,
-		const void *priv,
-		const hb_mc_coordinate_t *tgt,
-		const hb_mc_npa_t *npa,
-		hb_mc_eva_t *eva, size_t *sz)
+int default_npa_to_eva(hb_mc_manycore_t *mc,
+                       const void *priv,
+                       const hb_mc_coordinate_t *tgt,
+                       const hb_mc_npa_t *npa,
+                       hb_mc_eva_t *eva, size_t *sz)
 {
 	const hb_mc_coordinate_t *origin = (const hb_mc_coordinate_t*)priv;
+        const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
 
         if(default_npa_is_dram(cfg, npa, tgt))
                 return default_npa_to_eva_dram(cfg, origin, tgt, npa, eva, sz);
@@ -675,7 +676,7 @@ int default_npa_to_eva(const hb_mc_config_t *cfg,
  * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
  */
 int default_eva_size(
-	const hb_mc_config_t *cfg,
+        hb_mc_manycore_t *mc,
 	const void *priv,
 	const hb_mc_eva_t *eva,
 	size_t *sz)
@@ -683,7 +684,7 @@ int default_eva_size(
 	hb_mc_npa_t npa;
 	hb_mc_epa_t epa;
 	const hb_mc_coordinate_t *o;
-
+        const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
 	o = (const hb_mc_coordinate_t *) priv;
 
 	if(default_eva_is_dram(eva))
@@ -722,15 +723,15 @@ hb_mc_eva_map_t default_map = {
  * @param[out] sz     The size in bytes of the EVA segment for the #npa
  * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
  */
-int hb_mc_npa_to_eva(const hb_mc_config_t *cfg,
-		const hb_mc_eva_map_t *map,
-		const hb_mc_coordinate_t *tgt,
-		const hb_mc_npa_t *npa,
-		hb_mc_eva_t *eva, size_t *sz)
+int hb_mc_npa_to_eva(hb_mc_manycore_t *mc,
+                     const hb_mc_eva_map_t *map,
+                     const hb_mc_coordinate_t *tgt,
+                     const hb_mc_npa_t *npa,
+                     hb_mc_eva_t *eva, size_t *sz)
 {
 	int err;
 
-	err = map->npa_to_eva(cfg, map->priv, tgt, npa, eva, sz);
+	err = map->npa_to_eva(mc, map->priv, tgt, npa, eva, sz);
 	if (err != HB_MC_SUCCESS)
 		return err;
 
@@ -748,15 +749,15 @@ int hb_mc_npa_to_eva(const hb_mc_config_t *cfg,
  * @param[out] sz     The size in bytes of the NPA segment for the #eva
  * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
  */
-int hb_mc_eva_to_npa(const hb_mc_config_t *cfg,
-		const hb_mc_eva_map_t *map,
-		const hb_mc_coordinate_t *src,
-		const hb_mc_eva_t *eva,
-		hb_mc_npa_t *npa, size_t *sz)
+int hb_mc_eva_to_npa(hb_mc_manycore_t *mc,
+                     const hb_mc_eva_map_t *map,
+                     const hb_mc_coordinate_t *src,
+                     const hb_mc_eva_t *eva,
+                     hb_mc_npa_t *npa, size_t *sz)
 {
 	int err;
 
-	err = map->eva_to_npa(cfg, map->priv, src, eva, npa, sz);
+	err = map->eva_to_npa(mc, map->priv, src, eva, npa, sz);
 	if (err != HB_MC_SUCCESS)
 		return err;
 
@@ -771,13 +772,13 @@ int hb_mc_eva_to_npa(const hb_mc_config_t *cfg,
  * @param[out] sz     Number of contiguous bytes remaining in the #eva segment
  * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
  */
-int hb_mc_eva_size(const hb_mc_config_t *cfg,
-		const hb_mc_eva_map_t *map,
-		const hb_mc_eva_t *eva, size_t *sz)
+int hb_mc_eva_size(hb_mc_manycore_t *mc,
+                   const hb_mc_eva_map_t *map,
+                   const hb_mc_eva_t *eva, size_t *sz)
 {
 	int err;
 
-	err = map->eva_size(cfg, map->priv, eva, sz);
+	err = map->eva_size(mc, map->priv, eva, sz);
 	if (err != HB_MC_SUCCESS)
 		return err;
 
@@ -807,14 +808,12 @@ int hb_mc_manycore_eva_write(hb_mc_manycore_t *mc,
 			const void *data, size_t sz)
 {
 	int err;
-	const hb_mc_config_t* config;
 	size_t dest_sz, xfer_sz;
 	hb_mc_npa_t dest_npa;
 	char *destp;
-	config = hb_mc_manycore_get_config(mc);
 
-	err = hb_mc_eva_size(config, map, eva, &dest_sz);
-	if (err != HB_MC_SUCCESS) { 
+	err = hb_mc_eva_size(mc, map, eva, &dest_sz);
+	if (err != HB_MC_SUCCESS) {
 		bsg_pr_err("%s: failed to acquire eva size.\n", __func__);
 		return err;
 	}
@@ -826,7 +825,7 @@ int hb_mc_manycore_eva_write(hb_mc_manycore_t *mc,
 
 	destp = (char *)data;
 	while(sz > 0){
-		err = hb_mc_eva_to_npa(config, map, tgt, eva, &dest_npa, &dest_sz);
+		err = hb_mc_eva_to_npa(mc, map, tgt, eva, &dest_npa, &dest_sz);
 		if(err != HB_MC_SUCCESS){
 			bsg_pr_err("%s: Failed to translate EVA into a NPA\n",
 				__func__);
@@ -866,14 +865,11 @@ int hb_mc_manycore_eva_read(hb_mc_manycore_t *mc,
 			void *data, size_t sz)
 {
 	int err;
-	const hb_mc_config_t* config;
 	size_t src_sz, xfer_sz;
 	hb_mc_npa_t src_npa;
 	char *srcp;
 
-	config = hb_mc_manycore_get_config(mc);
-
-	err = hb_mc_eva_size(config, map, eva, &src_sz);
+	err = hb_mc_eva_size(mc, map, eva, &src_sz);
 	if (sz > src_sz){
 		bsg_pr_err("%s: Error, requested read from region that is smaller "
 			"than buffer\n", __func__);
@@ -882,7 +878,7 @@ int hb_mc_manycore_eva_read(hb_mc_manycore_t *mc,
 
 	srcp = (char *)data;
 	while(sz > 0){
-		err = hb_mc_eva_to_npa(config, map, tgt, eva, &src_npa, &src_sz);
+		err = hb_mc_eva_to_npa(mc, map, tgt, eva, &src_npa, &src_sz);
 		if(err != HB_MC_SUCCESS){
 			bsg_pr_err("%s: Failed to translate EVA into a NPA\n",
 				__func__);
@@ -922,12 +918,10 @@ int hb_mc_manycore_eva_memset(hb_mc_manycore_t *mc,
 			uint8_t val, size_t sz)
 {
 	int err;
-	const hb_mc_config_t* config;
 	size_t dest_sz, xfer_sz;
 	hb_mc_npa_t dest_npa;
-	config = hb_mc_manycore_get_config(mc);
 
-	err = hb_mc_eva_size(config, map, eva, &dest_sz);
+	err = hb_mc_eva_size(mc, map, eva, &dest_sz);
 	if (sz > dest_sz){
 		bsg_pr_err("%s: Error, requested copy to region that is smaller "
 			"than buffer\n", __func__);
@@ -935,7 +929,7 @@ int hb_mc_manycore_eva_memset(hb_mc_manycore_t *mc,
 	}
 
 	while(sz > 0){
-		err = hb_mc_eva_to_npa(config, map, tgt, eva, &dest_npa, &dest_sz);
+		err = hb_mc_eva_to_npa(mc, map, tgt, eva, &dest_npa, &dest_sz);
 		if(err != HB_MC_SUCCESS){
 			bsg_pr_err("%s: Failed to translate EVA into a NPA\n",
 				__func__);

--- a/cl_manycore/libraries/bsg_manycore_eva.cpp
+++ b/cl_manycore/libraries/bsg_manycore_eva.cpp
@@ -12,7 +12,7 @@
 
 
 
-#define MAKE_MASK(WIDTH) ((1ULL << WIDTH) - 1)
+#define MAKE_MASK(WIDTH) ((1ULL << (WIDTH)) - 1)
 
 #define DEFAULT_GROUP_X_LOGSZ 6
 #define DEFAULT_GROUP_X_BITIDX HB_MC_EPA_LOGSZ
@@ -325,7 +325,8 @@ static int default_eva_to_npa_dram(const hb_mc_config_t *cfg,
 
 	if (epa >= maxsz){
 		bsg_pr_err("%s: Translation of EVA 0x%08" PRIx32 " failed. EPA requested is "
-			"outside of addressible range in DRAM.");
+                           "outside of addressible range in DRAM.",
+                           __func__, hb_mc_eva_addr(eva));
 		return HB_MC_INVALID;
 	}
 
@@ -374,7 +375,7 @@ int default_eva_to_npa(const hb_mc_config_t *cfg,
 		return default_eva_to_npa_local(cfg, origin, src, eva, npa, sz);
 
 	bsg_pr_err("%s: EVA 0x%08" PRIx32 " did not map to a known region\n",
-		hb_mc_eva_addr(eva), __func__);
+                   __func__, hb_mc_eva_addr(eva));
 	return HB_MC_FAIL;
 }
 
@@ -695,7 +696,7 @@ int default_eva_size(
 		return default_eva_to_npa_local(cfg, o, o, eva, &npa, sz);
 
 	bsg_pr_err("%s: EVA 0x%08" PRIx32 " did not map to a known region\n",
-		hb_mc_eva_addr(eva), __func__);
+                   __func__, hb_mc_eva_addr(eva));
 	return HB_MC_FAIL;
 
 }

--- a/cl_manycore/libraries/bsg_manycore_eva.cpp
+++ b/cl_manycore/libraries/bsg_manycore_eva.cpp
@@ -277,7 +277,11 @@ static uint32_t default_get_dram_x_bitidx(const hb_mc_config_t *cfg)
 static uint32_t default_get_dram_x_shift(const hb_mc_manycore_t *mc)
 {
         const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
-        return hb_mc_config_get_vcache_bitwidth_data_addr(cfg);
+        if (hb_mc_manycore_dram_is_enabled(mc)) {
+                return hb_mc_config_get_vcache_bitwidth_data_addr(cfg);
+        } else {
+                return ceil(log2(hb_mc_config_get_vcache_size(cfg))); // clog2(victim cache size)
+        }
 }
 
 /**

--- a/cl_manycore/libraries/bsg_manycore_eva.h
+++ b/cl_manycore/libraries/bsg_manycore_eva.h
@@ -34,11 +34,11 @@ typedef struct __hb_mc_eva_map_t{
  * @param[out] sz     The size in bytes of the NPA segment for the #eva
  * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
  */
-	int (*eva_to_npa)(const hb_mc_config_t *cfg, 
-			const void *priv,
-			const hb_mc_coordinate_t *src, 
-			const hb_mc_eva_t *eva, 
-			hb_mc_npa_t *npa, size_t *sz);
+        int (*eva_to_npa)(hb_mc_manycore_t *mc,
+                          const void *priv,
+                          const hb_mc_coordinate_t *src,
+                          const hb_mc_eva_t *eva,
+                          hb_mc_npa_t *npa, size_t *sz);
 
 /**
  * Returns the number of contiguous bytes following an EVA, regardless of
@@ -49,7 +49,7 @@ typedef struct __hb_mc_eva_map_t{
  * @param[out] sz     Number of contiguous bytes remaining in the #eva segment
  * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
  */
-	int (*eva_size)(const hb_mc_config_t *cfg, 
+	int (*eva_size)(hb_mc_manycore_t *mc,
 			const void *priv,
 			const hb_mc_eva_t *eva, 
 			size_t *sz);
@@ -66,11 +66,11 @@ typedef struct __hb_mc_eva_map_t{
  * @param[out] sz     The size in bytes of the EVA segment for the #npa
  * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
  */
-	int (*npa_to_eva)(const hb_mc_config_t *cfg, 
-			const void *priv,
-			const hb_mc_coordinate_t *tgt, 
-			const hb_mc_npa_t *npa, 
-			hb_mc_eva_t *eva, size_t *sz);
+	int (*npa_to_eva)(hb_mc_manycore_t *mc,
+                          const void *priv,
+                          const hb_mc_coordinate_t *tgt,
+                          const hb_mc_npa_t *npa,
+                          hb_mc_eva_t *eva, size_t *sz);
 } hb_mc_eva_map_t;
 
 /**
@@ -84,7 +84,7 @@ typedef struct __hb_mc_eva_map_t{
  * @param[out] sz     The size in bytes of the NPA segment for the #eva
  * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
  */
-int default_eva_to_npa(const hb_mc_config_t *cfg, 
+int default_eva_to_npa(hb_mc_manycore_t *mc,
 		const void *priv,
 		const hb_mc_coordinate_t *src, 
 		const hb_mc_eva_t *eva,
@@ -102,11 +102,11 @@ int default_eva_to_npa(const hb_mc_config_t *cfg,
  * @param[out] sz     The size in bytes of the EVA segment for the #npa
  * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
  */
-int default_npa_to_eva(const hb_mc_config_t *cfg,
-		const void *priv,
-		const hb_mc_coordinate_t *tgt, 
-		const hb_mc_npa_t *npa, 
-		hb_mc_eva_t *eva, size_t *sz);
+int default_npa_to_eva(hb_mc_manycore_t *mc,
+                       const void *priv,
+                       const hb_mc_coordinate_t *tgt,
+                       const hb_mc_npa_t *npa,
+                       hb_mc_eva_t *eva, size_t *sz);
 
 /**
  * Returns the number of contiguous bytes following an EVA, regardless of
@@ -118,7 +118,7 @@ int default_npa_to_eva(const hb_mc_config_t *cfg,
  * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
  */
 int default_eva_size(
-	const hb_mc_config_t *cfg,
+        hb_mc_manycore_t *mc,
 	const void *priv,
 	const hb_mc_eva_t *eva,
 	size_t *sz);
@@ -149,10 +149,10 @@ static inline const char *hb_mc_eva_map_get_name(const hb_mc_eva_map_t *map)
  * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
  */
 __attribute__((warn_unused_result))
-int hb_mc_npa_to_eva(const hb_mc_config_t *cfg, 
-		const hb_mc_eva_map_t *map, 
+int hb_mc_npa_to_eva(hb_mc_manycore_t *mc,
+		const hb_mc_eva_map_t *map,
 		const hb_mc_coordinate_t *tgt,
-		const hb_mc_npa_t *npa, 
+		const hb_mc_npa_t *npa,
 		hb_mc_eva_t *eva, size_t *sz);
 
 /**
@@ -167,10 +167,10 @@ int hb_mc_npa_to_eva(const hb_mc_config_t *cfg,
  * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
  */
 __attribute__((warn_unused_result))
-int hb_mc_eva_to_npa(const hb_mc_config_t *cfg, 
-		const hb_mc_eva_map_t *map, 
-		const hb_mc_coordinate_t *src, 
-		const hb_mc_eva_t *eva, 
+int hb_mc_eva_to_npa(hb_mc_manycore_t *mc,
+		const hb_mc_eva_map_t *map,
+		const hb_mc_coordinate_t *src,
+		const hb_mc_eva_t *eva,
 		hb_mc_npa_t *npa, size_t *sz);
 
 /**

--- a/cl_manycore/libraries/bsg_manycore_loader.cpp
+++ b/cl_manycore/libraries/bsg_manycore_loader.cpp
@@ -695,9 +695,9 @@ static int hb_mc_loader_tile_set_registers(hb_mc_manycore_t *mc,
 
 	/* set/clear DRAM enabled */
 	if (hb_mc_manycore_dram_is_enabled(mc)) {
-		rc = hb_mc_set_dram_enabled(mc, &tile);
+		rc = hb_mc_tile_set_dram_enabled(mc, &tile);
 	} else {
-		rc = hb_mc_clear_dram_enabled(mc, &tile);
+		rc = hb_mc_tile_clear_dram_enabled(mc, &tile);
 	}
 
 	if (rc != HB_MC_SUCCESS) {

--- a/cl_manycore/libraries/bsg_manycore_loader.cpp
+++ b/cl_manycore/libraries/bsg_manycore_loader.cpp
@@ -693,6 +693,22 @@ static int hb_mc_loader_tile_set_registers(hb_mc_manycore_t *mc,
 		return rc;
 	}
 
+	/* set/clear DRAM enabled */
+	if (hb_mc_manycore_dram_is_enabled(mc)) {
+		rc = hb_mc_set_dram_enabled(mc, &tile);
+	} else {
+		rc = hb_mc_clear_dram_enabled(mc, &tile);
+	}
+
+	if (rc != HB_MC_SUCCESS) {
+		char tile_str[32];
+		bsg_pr_dbg("%s: failed to %s DRAM-enabled for %s: %s\n",
+			   __func__,
+			   hb_mc_manycore_dram_is_enabled(mc) ? "set" : "clear",
+			   hb_mc_coordinate_to_string(tile, tile_str, sizeof(tile_str)));
+		return rc;
+	}
+
 	return HB_MC_SUCCESS;
 }
 

--- a/cl_manycore/libraries/bsg_manycore_loader.cpp
+++ b/cl_manycore/libraries/bsg_manycore_loader.cpp
@@ -737,6 +737,68 @@ static int hb_mc_loader_tile_initialize(hb_mc_manycore_t *mc,
 }
 
 /**
+ * Performance miscellaneous initialization on one tile.
+ * @param[in] mc      A manycore instance.
+ * @param[in] map     An EVA<->NPA map.
+ * @param[in] col     The column whose victim cache to validate.
+ * @return HB_MC_SUCCESS if an error occured. Otherwise an error code is returned.
+ */
+static int hb_mc_loader_column_validate_victim_cache(hb_mc_manycore_t *mc,
+						     const hb_mc_eva_map_t *map,
+						     hb_mc_idx_t col)
+{
+	const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
+	hb_mc_idx_t x = hb_mc_config_get_vcore_base_x(cfg) + col;
+	uint32_t n_ways = hb_mc_config_get_vcache_ways(cfg);
+	uint32_t n_sets = hb_mc_config_get_vcache_sets(cfg);
+	uint32_t line_size = hb_mc_config_get_vcache_block_size(cfg);
+	hb_mc_npa_t tag_addr = hb_mc_npa_from_x_y(x, 0, HB_MC_VCACHE_EPA_TAG);
+	int rc;
+
+	/* for each cache line... */
+	for (uint32_t cache_way = 0; cache_way = n_ways; cache_way++) {
+		for (uint32_t cache_set = 0; cache_set < n_sets; cache_set++) {
+			/* set the tag to the way index and set the valid bit */
+			rc = hb_mc_manycore_write32(mc, &tag_addr,
+						    HB_MC_VCACHE_VALID | cache_way);
+			if (rc != HB_MC_SUCCESS)
+				return rc;
+
+			/* increment to the next line */
+			hb_mc_npa_set_epa(&tag_addr,
+					  hb_mc_npa_get_epa(&tag_addr) + line_size);
+		}
+	}
+
+	return HB_MC_SUCCESS;
+}
+
+/**
+ * Validate all victim cache tags.
+ * @param[in] mc      A manycore instance.
+ * @param[in] map     An EVA<->NPA map.
+ * @param[in] tiles   The list of tiles to initialize.
+ * @param[in] ntiles  The number of tiles to initialize.
+ * @return HB_MC_SUCCESS if an error occured. Otherwise an error code is returned.
+ */
+static int hb_mc_loader_columns_validate_victim_cache(hb_mc_manycore_t *mc,
+						      const hb_mc_eva_map_t *map)
+{
+	const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
+	hb_mc_idx_t n_columns = hb_mc_dimension_get_x(hb_mc_config_get_dimension_vcore(cfg));
+	int rc;
+
+	/* for each column... */
+	for (hb_mc_idx_t col = 0; col < n_columns; col++) {
+		rc = hb_mc_loader_column_validate_victim_cache(mc, map, col);
+		if (rc != HB_MC_SUCCESS)
+			return rc;
+	}
+
+	return HB_MC_SUCCESS;
+}
+
+/**
  * Performance miscellaneous initialization of tiles.
  * @param[in] mc      A manycore instance.
  * @param[in] map     An EVA<->NPA map.
@@ -756,6 +818,13 @@ static int hb_mc_loader_tiles_initialize(hb_mc_manycore_t *mc,
 
 	for (uint32_t i = 0; i < ntiles; i++) {
 		rc = hb_mc_loader_tile_initialize(mc, map, tiles[i], tiles, ntiles);
+		if (rc != HB_MC_SUCCESS)
+			return rc;
+	}
+
+	/* validate all vcache tags if we're in no-DRAM mode */
+	if (!hb_mc_manycore_dram_is_enabled(mc)) {
+		rc = hb_mc_loader_columns_validate_victim_cache(mc, map);
 		if (rc != HB_MC_SUCCESS)
 			return rc;
 	}

--- a/cl_manycore/libraries/bsg_manycore_loader.cpp
+++ b/cl_manycore/libraries/bsg_manycore_loader.cpp
@@ -756,7 +756,7 @@ static int hb_mc_loader_column_validate_victim_cache(hb_mc_manycore_t *mc,
 	int rc;
 
 	/* for each cache line... */
-	for (uint32_t cache_way = 0; cache_way = n_ways; cache_way++) {
+	for (uint32_t cache_way = 0; cache_way < n_ways; cache_way++) {
 		for (uint32_t cache_set = 0; cache_set < n_sets; cache_set++) {
 			/* set the tag to the way index and set the valid bit */
 			rc = hb_mc_manycore_write32(mc, &tag_addr,

--- a/cl_manycore/libraries/bsg_manycore_loader.cpp
+++ b/cl_manycore/libraries/bsg_manycore_loader.cpp
@@ -1037,9 +1037,9 @@ int hb_mc_loader_symbol_to_eva(const void *bin, size_t sz, const char *symbol,
 
 
 /**
- * Takes in the path to a binary and loads the binary into a buffer and set the binary size. 
- * @param[in]  file_name  Path and name of the binary file 
- * @param[out] file_data  Pointer to the memory buffer to be loaded with a valid binary 
+ * Takes in the path to a binary and loads the binary into a buffer and set the binary size.
+ * @param[in]  file_name  Path and name of the binary file
+ * @param[out] file_data  Pointer to the memory buffer to be loaded with a valid binary
  * @param[out] file_size  Size of binary in bytes.
  * @return HB_MC_FAIL if an error occured. HB_MC_SUCCESS otherwise.
  */

--- a/cl_manycore/libraries/bsg_manycore_loader.cpp
+++ b/cl_manycore/libraries/bsg_manycore_loader.cpp
@@ -749,11 +749,22 @@ static int hb_mc_loader_column_validate_victim_cache(hb_mc_manycore_t *mc,
 {
 	const hb_mc_config_t *cfg = hb_mc_manycore_get_config(mc);
 	hb_mc_idx_t x = hb_mc_config_get_vcore_base_x(cfg) + col;
+	hb_mc_idx_t y = hb_mc_config_get_dram_y(cfg);
 	uint32_t n_ways = hb_mc_config_get_vcache_ways(cfg);
 	uint32_t n_sets = hb_mc_config_get_vcache_sets(cfg);
 	uint32_t line_size = hb_mc_config_get_vcache_block_size(cfg);
-	hb_mc_npa_t tag_addr = hb_mc_npa_from_x_y(x, 0, HB_MC_VCACHE_EPA_TAG);
+	hb_mc_npa_t tag_addr = hb_mc_npa_from_x_y(x, y, HB_MC_VCACHE_EPA_TAG);
 	int rc;
+
+	bsg_pr_dbg("validating victim cache "
+		   "(%" PRIu32 " ways, "
+		   "%" PRIu32 " sets, "
+		   "line size = %" PRIu32 ") "
+		   "for column %" PRIu8 "\n",
+		   n_ways,
+		   n_sets,
+		   line_size,
+		   x);
 
 	/* for each cache line... */
 	for (uint32_t cache_way = 0; cache_way < n_ways; cache_way++) {

--- a/cl_manycore/libraries/bsg_manycore_vcache.h
+++ b/cl_manycore/libraries/bsg_manycore_vcache.h
@@ -30,6 +30,10 @@ extern "C" {
 #define HB_MC_VCACHE_EPA_TAG						\
 	EPA_VCACHE_FROM_BYTE_OFFSET(HB_MC_VCACHE_EPA_OFFSET_TAG)
 
+/* Victim Cache Data Bits */
+#define HB_MC_VCACHE_VALID_BITIDX 31
+#define HB_MC_VCACHE_VALID (1 << HB_MC_VCACHE_VALID_BITIDX)
+
 #ifdef __cplusplus
 };
 #endif

--- a/cl_manycore/regression/library/test_manycore_eva.c
+++ b/cl_manycore/regression/library/test_manycore_eva.c
@@ -147,7 +147,7 @@ int test_manycore_eva () {
 		}
 		
 		result_x = 0; result_y = 0; result_epa = 0; result_sz = 0;
-		rc = hb_mc_eva_to_npa(config, &default_map, &src,
+		rc = hb_mc_eva_to_npa(&mc, &default_map, &src,
 				&eva, &result_npa, &result_sz);
 		if(rc != HB_MC_SUCCESS){
 			bsg_pr_test_err("Call to hb_mc_manycore_eva_to_npa failed\n", eva);

--- a/cl_manycore/regression/library/test_manycore_eva_read_write.c
+++ b/cl_manycore/regression/library/test_manycore_eva_read_write.c
@@ -56,10 +56,8 @@ int check_npa_read(hb_mc_manycore_t *mc, hb_mc_eva_map_t *map, hb_mc_coordinate_
 	int err, errors, i;
 	size_t sz;
 	hb_mc_npa_t npa;
-	const hb_mc_config_t *cfg;
 
-	cfg = hb_mc_manycore_get_config(mc);
-	err = hb_mc_eva_to_npa(cfg, map, target, eva, &npa, &sz);
+	err = hb_mc_eva_to_npa(mc, map, target, eva, &npa, &sz);
 	if (err != HB_MC_SUCCESS) {
 		bsg_pr_err("%s: failed to translate EVA 0x%x to NPA: %s\n",
 			__func__,

--- a/cl_manycore/regression/spmd/test_bsg_loader_suite.c
+++ b/cl_manycore/regression/spmd/test_bsg_loader_suite.c
@@ -385,7 +385,7 @@ static int run_npa_to_eva_test(test_t *test)
 	 */
 	hb_mc_eva_t addr;
 	size_t addr_bytes;
-	err = hb_mc_npa_to_eva(hb_mc_manycore_get_config(mc),
+	err = hb_mc_npa_to_eva(mc,
 			       &default_map,
 			       &target,
 			       &npa,


### PR DESCRIPTION
* Extends the `hb_mc_manycore` API to support HammerBlade hardware operating without off-chip memory
* Extends the `hb_mc_config` API for values derived from top-level parameters
* Modifies the `hb_mc_eva` API to take an `hb_mc_manycore` instance (it had to be done... I'm sorry)
* Modifies the `default_eva_map` implementation to automatically handle No-DRAM mode
* Modifies the `hb_mc_loader_load` implementation to automatically handle No-DRAM mode
* adds function `hb_mc_manycore_enable_dram()`
* adds function `hb_mc_manycore_disable_dram()`
* modifies `hb_mc_manycore_dram_is_enabled()` to return a runtime value
* adds function `hb_mc_config_get_vcache_block_size()`
* adds function `hb_mc_config_get_vcache_size()`
* `bsg_manycore_eva.cpp` and `bsg_manycore_origin_eva_map.cpp` are compiled natively with stricter compile-time checks.
