### PR TITLE
Bugfix for xdim_max computation in bsg_manycore_config

### DIFF
--- a/cl_manycore/libraries/bsg_manycore_config.cpp
+++ b/cl_manycore/libraries/bsg_manycore_config.cpp
@@ -62,7 +62,7 @@ int hb_mc_config_init(const hb_mc_config_raw_t raw[HB_MC_CONFIG_MAX],
 	/* The maximum X dimension of the network is limited by the network
 	 * address bitwidth */
 	xlogsz_max = HB_MC_CONFIG_MAX_BITWIDTH_ADDR - config->network_bitwidth_addr;
-	xdim_max = (xlogsz_max - 1) << 1;
+	xdim_max = (1 << xlogsz_max) - 1;
 
         idx = raw[HB_MC_CONFIG_DEVICE_DIM_X];
         if ((idx < HB_MC_COORDINATE_MIN) || (idx > xdim_max)){

--- a/cl_manycore/libraries/bsg_manycore_config.cpp
+++ b/cl_manycore/libraries/bsg_manycore_config.cpp
@@ -62,7 +62,7 @@ int hb_mc_config_init(const hb_mc_config_raw_t raw[HB_MC_CONFIG_MAX],
 	/* The maximum X dimension of the network is limited by the network
 	 * address bitwidth */
 	xlogsz_max = HB_MC_CONFIG_MAX_BITWIDTH_ADDR - config->network_bitwidth_addr;
-	xdim_max = (1 << xlogsz_max) - 1;
+	xdim_max = (1 << xlogsz_max);
 
         idx = raw[HB_MC_CONFIG_DEVICE_DIM_X];
         if ((idx < HB_MC_COORDINATE_MIN) || (idx > xdim_max)){

--- a/cl_manycore/libraries/bsg_manycore_config.h
+++ b/cl_manycore/libraries/bsg_manycore_config.h
@@ -24,8 +24,8 @@
 extern "C" {
 #endif
 
-// We expect a 32-bit bus for Addresses, but the top bit is reserved for the
-// victim cache tag.
+// We expect a 32-bit bus for Addresses, but two bits are removed because the
+// network uses word-level addressing and handles byte-writes with a mask
 #define HB_MC_CONFIG_MAX_BITWIDTH_ADDR 30
 #define HB_MC_CONFIG_MAX_BITWIDTH_DATA 32
 

--- a/cl_manycore/libraries/bsg_manycore_config.h
+++ b/cl_manycore/libraries/bsg_manycore_config.h
@@ -26,7 +26,7 @@ extern "C" {
 
 // We expect a 32-bit bus for Addresses, but the top bit is reserved for the
 // victim cache tag.
-#define HB_MC_CONFIG_MAX_BITWIDTH_ADDR 31
+#define HB_MC_CONFIG_MAX_BITWIDTH_ADDR 30
 #define HB_MC_CONFIG_MAX_BITWIDTH_DATA 32
 
 #define HB_MC_CONFIG_VCORE_BASE_X 0


### PR DESCRIPTION
Found this while trying to increase the manycore dimensions