### PR TITLE
Feature cadenv search

### DIFF
--- a/cl_manycore/Makefile.environment
+++ b/cl_manycore/Makefile.environment
@@ -6,6 +6,7 @@ CL_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 ifneq ("$(wildcard $(CL_DIR)/../../bsg_cadenv/cadenv.mk)","")
 $(warning $(shell echo -e "\t\n\t$(ORANGE)Found bsg_cadenv. Including cadenv.mk.$(NC)"))
 include $(CL_DIR)/../../bsg_cadenv/cadenv.mk
+export VCS_HOME=$(VCS_MX_HOME)
 endif
 
 ifneq ("$(wildcard $(CL_DIR)/../../Makefile.deps)","")

--- a/cl_manycore/Makefile.environment
+++ b/cl_manycore/Makefile.environment
@@ -3,6 +3,11 @@ NC=\033[0m
 
 CL_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
+ifneq ("$(wildcard $(CL_DIR)/../../bsg_cadenv/cadenv.mk)","")
+$(warning $(shell echo -e "\t\n\t$(ORANGE)Found bsg_cadenv. Including cadenv.mk.$(NC)"))
+include $(CL_DIR)/../../bsg_cadenv/cadenv.mk
+endif
+
 ifneq ("$(wildcard $(CL_DIR)/../../Makefile.deps)","")
 
 # Default to overriding BSG_IP_CORES_DIR and BSG_MANYCORE_DIR and warn


### PR DESCRIPTION
* Added support for cadenv


I've added support for cadenv. The default behavior is to use environment variables for VCS and Vivado (since that's necessary for F1/Cornell) but if any UW people want to use cadenv, it will now be found