### PR TITLE
changing instance name so that profiler can match string to print out…

### DIFF
--- a/cl_manycore/hardware/bsg_cache_wrapper_axi.v
+++ b/cl_manycore/hardware/bsg_cache_wrapper_axi.v
@@ -146,7 +146,7 @@ module bsg_cache_wrapper_axi
       ,.data_width_p(data_width_p)
       ,.block_size_in_words_p(block_size_in_words_p)
       ,.sets_p(sets_p)
-    ) cache (
+    ) vcache (
       .clk_i(clk_i)
       ,.reset_i(reset_i)
       


### PR DESCRIPTION
… header only once.