### PR TITLE
Add back test_matrix_mul_shared_mem to regression tests

### DIFF
--- a/cl_manycore/regression/cuda/Makefile.tests
+++ b/cl_manycore/regression/cuda/Makefile.tests
@@ -24,7 +24,7 @@ INDEPENDENT_TESTS += test_max_pool2d
 INDEPENDENT_TESTS += test_shared_mem
 INDEPENDENT_TESTS += test_shared_mem_load_store
 INDEPENDENT_TESTS += test_matrix_mul
-#INDEPENDENT_TESTS += test_matrix_mul_shared_mem
+INDEPENDENT_TESTS += test_matrix_mul_shared_mem
 
 INDEPENDENT_TESTS += test_float_vec_add
 INDEPENDENT_TESTS += test_float_vec_add_shared_mem


### PR DESCRIPTION
The bug in matrix multiplication with tile group shared memory that appeared in cosim is now fixed. So the test is added back into the list of regression lists. 
Credit and huge thanks to @drichmond for his help! 
Related PR # 119 in bsg_manycore. 