### PR TITLE
Added timing to hb_mc_tile_groups_execute() 

### DIFF
--- a/libraries/bsg_manycore_cuda.cpp
+++ b/libraries/bsg_manycore_cuda.cpp
@@ -1443,6 +1443,7 @@ static int hb_mc_device_wait_for_tile_group_finish_any(hb_mc_device_t *device) {
  */
 int hb_mc_device_tile_groups_execute (hb_mc_device_t *device) {
 
+	clock_t start_time = clock();
 	int error ;
 	/* loop untill all tile groups have been allocated, launched and finished. */
 	while(hb_mc_device_all_tile_groups_finished(device) != HB_MC_SUCCESS) {
@@ -1469,6 +1470,9 @@ int hb_mc_device_tile_groups_execute (hb_mc_device_t *device) {
 		}
 
 	}
+
+	clock_t end_time = clock();
+	bsg_pr_info("Execution Cycles: %d\tTime(s): %e\n", (end_time - start_time), (float) (end_time - start_time) / CLOCKS_PER_SEC);
 
 	return HB_MC_SUCCESS;
 }

--- a/libraries/bsg_manycore_cuda.h
+++ b/libraries/bsg_manycore_cuda.h
@@ -5,8 +5,10 @@
 
 #ifdef __cplusplus
 #include <cstdint>
+#include <ctime>
 #else
 #include <stdint.h>
+#include <time.h>
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
function to print the total execution time in both cycles and seconds.
Currently timing results seem to be wrong. Do NOT merge until discussed. 
