### PR TITLE
Added missing files to filelist

### DIFF
--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -72,6 +72,11 @@ VSOURCES += $(CL_DIR)/hardware/s_axil_mcl_adapter.v
 VSOURCES += $(CL_DIR)/hardware/axil_to_mem.sv
 
 VHEADERS += $(HARDWARE_PATH)/f1_parameters.vh
+VHEADERS += $(HARDWARE_PATH)/axil_to_mcl.vh
+VHEADERS += $(HARDWARE_PATH)/bsg_axi_bus_pkg.vh
+VHEADERS += $(HARDWARE_PATH)/bsg_bladerunner_rom_pkg.vh
+VHEADERS += $(HARDWARE_PATH)/cl_manycore_defines.vh
+VHEADERS += $(HARDWARE_PATH)/cl_id_defines.vh
 
 $(HARDWARE_PATH)/bsg_bladerunner_configuration.rom: $(CL_DIR)/Makefile.machine.include
 	python $(HARDWARE_PATH)/create_bladerunner_rom.py \


### PR DESCRIPTION
We're still missing some files to make #414  work:

diff master vs PR #414

```
< bsg_arb_fixed.v
38d36
< bsg_cache_wrapper_axi.v
40d37
< bsg_clkgate_optional.v
44d40
< bsg_cycle_counter.v
52d47
< bsg_dlatch.v
54c49
< bsg_fifo_1r1w_large.v
---
> bsg_expand_bitmask.v
56d50
< bsg_fifo_1rw_large.v
71a66,67
> bsg_lru_pseudo_tree_decode.v
> bsg_lru_pseudo_tree_encode.v
73d68
< bsg_manycore_addr.vh
81d75
< bsg_manycore_packet.vh
96,97d89
< bsg_mem_banked_crossbar.v
< bsg_mem_cfg_pkg.v
105d96
< bsg_noc_links.vh
107,109d97
< bsg_nonsynth_mem_1rw_sync_assoc.v
< bsg_nonsynth_mem_1rw_sync_mask_write_byte_assoc.v
< bsg_nonsynth_mem_infinite.v
115d102
< bsg_round_robin_2_to_2.v
120d106
< bsg_thermometer_count.v
129d114
< definitions.vh
144d128
< memory_system.v
147d130
< parameters.vh
159d141
< vanilla_core_profiler.v
161d142
< vcache_profiler.v

```