### PR TITLE
Fixes the double freeing of binary bug

### DIFF
--- a/libraries/bsg_manycore_cuda.cpp
+++ b/libraries/bsg_manycore_cuda.cpp
@@ -115,6 +115,11 @@ __attribute__((warn_unused_result))
 static int hb_mc_device_program_exit (hb_mc_program_t *program); 
 
 __attribute__((warn_unused_result))
+static int hb_mc_program_binary_copy (hb_mc_program_t *program,
+                                      const unsigned char *bin_data,
+                                      size_t bin_size); 
+
+__attribute__((warn_unused_result))
 static int hb_mc_program_allocator_init (const hb_mc_config_t *cfg,
                                          hb_mc_program_t *program,
                                          const char *name,
@@ -1136,9 +1141,14 @@ int hb_mc_device_program_init_binary (hb_mc_device_t *device,
 	}
 
 
-	device->program->bin = bin_data;
-
-	device->program->bin_size = bin_size;
+	// Copy binary into device's program struct and set it's size in characters
+	error = hb_mc_program_binary_copy (device->program,
+                                           bin_data,
+                                           bin_size);
+	if (error != HB_MC_SUCCESS) { 
+		bsg_pr_err("%s: failed to copy binary into program struct.\n", __func__); 
+		return error;
+	}
 
 
 	// Initialize program's memory allocator
@@ -1280,6 +1290,34 @@ static int hb_mc_device_program_exit (hb_mc_program_t *program) {
 }
 
 
+
+
+/**
+ * Copies the binary into the hb_mc_program_t struct's binary section
+ * And sets the program's binary size in characters 
+ * @param[in]  program       Pointer to program
+ * @param[in]  bin_data      Buffer containing the binary
+ * @param[in]  bin_size      Size of binary in characters
+ * @return HB_MC_SUCCESS if succesful. Otherwise an error code is returned.
+ */
+static int hb_mc_program_binary_copy (hb_mc_program_t *program,
+                                      const unsigned char *bin_data,
+                                      size_t bin_size) { 
+	unsigned char* copy = (unsigned char*) malloc (bin_size);
+	if (!copy){ 
+		bsg_pr_err("%s: failed to allocated space on device for program binary.\n", __func__);
+		return HB_MC_NOMEM;
+	}
+
+	for (int ptr = 0; ptr < bin_size; ptr++){
+		copy[ptr] = bin_data[ptr];
+	}
+
+	program->bin = copy; 
+	program->bin_size = bin_size;
+
+	return HB_MC_SUCCESS;	
+}
 
 
 

--- a/libraries/bsg_manycore_cuda.cpp
+++ b/libraries/bsg_manycore_cuda.cpp
@@ -1303,16 +1303,20 @@ static int hb_mc_device_program_exit (hb_mc_program_t *program) {
 static int hb_mc_program_binary_copy (hb_mc_program_t *program,
                                       const unsigned char *bin_data,
                                       size_t bin_size) { 
+
+	if (!bin_data) {
+		bsg_pr_err("%s: binary is null.\n", __func__);
+		return HB_MC_INVALID;
+	}
+
 	unsigned char* copy = (unsigned char*) malloc (bin_size);
 	if (!copy){ 
 		bsg_pr_err("%s: failed to allocated space on device for program binary.\n", __func__);
 		return HB_MC_NOMEM;
 	}
 
-	for (int ptr = 0; ptr < bin_size; ptr++){
-		copy[ptr] = bin_data[ptr];
-	}
-
+	memcpy((unsigned char*) copy, (const unsigned char*) bin_data, bin_size);
+	
 	program->bin = copy; 
 	program->bin_size = bin_size;
 

--- a/regression/cuda/test_binary_load_buffer.c
+++ b/regression/cuda/test_binary_load_buffer.c
@@ -1,0 +1,174 @@
+// Copyright (c) 2019, University of Washington All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+// 
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+// 
+// Neither the name of the copyright holder nor the names of its contributors may
+// be used to endorse or promote products derived from this software without
+// specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/******************************************************************************/
+/* Runs an empty kernel on a 1x1 grid of 2x2 tile group.                      */
+/* Tests the correctness of hb_mc_program_init_binary cuda API function       */
+/* Where instead of passing the path to binary to hb_mc_program_init,         */
+/* A pre-loaded buffer of the binary is passed to hb_mc_program_init_binary.  */
+/* Grid dimensions are prefixed at 1x1. Tilegroup dimensions pre-fixed at 2x2.*/
+/* This tests uses the software/spmd/bsg_cuda_lite_runtime/binary_load_buffer/*/
+/* manycore binary in the BSG Manycore repository.                            */
+/******************************************************************************/
+
+
+#include "test_binary_load_buffer.h"
+
+#define TEST_NAME "test_binary_load_buffer"
+#define ALLOC_NAME "default_allocator"
+
+
+int kernel_binary_load_buffer() {
+	bsg_pr_test_info("Running the CUDA Empty Kernel using a pre-loaded "
+                         "binary buffer on a 1x1 grid of 2x2 tile group.\n\n");
+	int rc;
+
+	srand(time); 
+
+
+        /**********************************************************************/
+        /* Define path to binary.                                             */
+        /* Initialize device, load binary and unfreeze tiles.                 */
+	/* In this test, we use hb_mc_program_init_binary instead of          */
+	/* hb_mc_program_init, meaning the binary is already pre-loaded into a*/
+	/* buffer and passed into the program_init function isntead of passing*/
+	/* a address to the binary.                                           */
+        /**********************************************************************/
+	hb_mc_device_t device;
+	rc = hb_mc_device_init(&device, TEST_NAME, 0);
+	if (rc != HB_MC_SUCCESS) { 
+		bsg_pr_err("failed to initialize device.\n");
+		return rc;
+	}
+
+
+	char* elf = BSG_STRINGIFY(BSG_MANYCORE_DIR) "/software/spmd/bsg_cuda_lite_runtime"
+                                                    "/binary_load_buffer/main.riscv";
+	unsigned char* bin_data;
+	size_t bin_size;
+
+	rc = hb_mc_loader_read_program_file (elf, &bin_data, &bin_size);
+	if (rc != HB_MC_SUCCESS) { 
+		bsg_pr_err ("%s: failed to read binary file.\n", __func__); 
+		return rc;
+	}
+
+
+	rc = hb_mc_device_program_init_binary (&device,
+                                               TEST_NAME, 
+                                               bin_data,
+                                               bin_size, 
+                                               ALLOC_NAME,
+                                               0); 
+	if (rc != HB_MC_SUCCESS) { 
+		bsg_pr_err ("%s: failed to initialize progarm.\n", __func__); 
+		return rc;
+	}
+
+	// Free the binary buffer
+	free (bin_data);
+
+
+        /**********************************************************************/
+	/* Define tg_dim_x/y: number of tiles in each tile group              */
+	/* Define grid_dim_x/y: number of tile groups needed.                 */
+        /**********************************************************************/
+
+	hb_mc_dimension_t tg_dim = { .x = 2, .y = 2}; 
+
+	hb_mc_dimension_t grid_dim = { .x = 1, .y = 1}; 
+
+
+        /**********************************************************************/
+	/* Prepare list of input arguments for kernel.                        */
+        /**********************************************************************/
+	int argv[1] = {};
+
+	
+        /**********************************************************************/
+	/* Enquque grid of tile groups, pass in grid and tile group dimensions*/
+        /* kernel name, number and list of input arguments                    */
+        /**********************************************************************/
+	rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_binary_load_buffer", 0, argv);
+	if (rc != HB_MC_SUCCESS) { 
+		bsg_pr_err("failed to initialize grid.\n");
+		return rc;
+	}
+
+
+        /**********************************************************************/
+	/* Launch and execute all tile groups on device and wait for finish.  */ 
+        /**********************************************************************/
+	rc = hb_mc_device_tile_groups_execute(&device);
+	if (rc != HB_MC_SUCCESS) { 
+		bsg_pr_err("failed to execute tile groups.\n");
+		return rc;
+	}
+
+
+        /**********************************************************************/
+        /* Freeze the tiles and memory manager cleanup.                       */
+        /**********************************************************************/
+	rc = hb_mc_device_finish(&device); 
+	if (rc != HB_MC_SUCCESS) { 
+		bsg_pr_err("failed to de-initialize device.\n");
+		return rc;
+	}
+
+	return HB_MC_SUCCESS;
+}
+
+#ifdef COSIM
+void cosim_main(uint32_t *exit_code, char * args) {
+        // We aren't passed command line arguments directly so we parse them
+        // from *args. args is a string from VCS - to pass a string of arguments
+        // to args, pass c_args to VCS as follows: +c_args="<space separated
+        // list of args>"
+        int argc = get_argc(args);
+        char *argv[argc];
+        get_argv(args, argc, argv);
+
+#ifdef VCS
+	svScope scope;
+	scope = svGetScopeFromName("tb");
+	svSetScope(scope);
+#endif
+	bsg_pr_test_info("test_binary_load_buffer Regression Test (COSIMULATION)\n");
+	int rc = kernel_binary_load_buffer();
+	*exit_code = rc;
+	bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
+	return;
+}
+#else
+int main(int argc, char ** argv) {
+	bsg_pr_test_info("test_binary_load_buffer Regression Test (F1)\n");
+	int rc = kernel_binary_load_buffer();
+	bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
+	return rc;
+}
+#endif
+

--- a/regression/cuda/test_binary_load_buffer.h
+++ b/regression/cuda/test_binary_load_buffer.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2019, University of Washington All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+// 
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+// 
+// Neither the name of the copyright holder nor the names of its contributors may
+// be used to endorse or promote products derived from this software without
+// specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef TEST_BINARY_LOAD_BUFFER_H
+#define TEST_BINARY_LOAD_BUFFER_H
+
+
+#include <stdio.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <string.h>
+#include <time.h>
+#include <stdlib.h>
+
+#include "cuda_tests.h"
+
+
+#endif

--- a/regression/cuda/tests.mk
+++ b/regression/cuda/tests.mk
@@ -46,6 +46,7 @@ UNIFIED_TESTS += test_tile_info
 UNIFIED_TESTS += test_barrier
 
 # "Independent Tests" use a per-test <test_name>.c file
+INDEPENDENT_TESTS += test_binary_load_buffer
 INDEPENDENT_TESTS += test_empty_parallel
 INDEPENDENT_TESTS += test_multiple_binary_load
 INDEPENDENT_TESTS += test_memset


### PR DESCRIPTION
Related to issue #337.
- Added static hb_mc_program_binary_copy() CUDA API function to copy the binary buffer into hb_mc_program_t struct instead of pointing to the buffer.
- Added a cuda regression test test_binary_load_buffer to test the correctness of hb_mc_program_init_binary function that loads binary onto tiles from a pre-loaded buffer instead of loading it from a given path, and to test if the double freeing of binary bug is fixed.
F1 passed.
**merge with PR # 166 in bsg_manycore.**

