### PR TITLE
Added missing variable check in simlibs.mk

### DIFF
--- a/testbenches/simlibs.mk
+++ b/testbenches/simlibs.mk
@@ -50,6 +50,12 @@ ifndef LIBRARIES_PATH
 $(error $(shell echo -e "$(RED)BSG MAKE ERROR: LIBRARIES_PATH is not defined$(NC)"))
 endif
 
+# PROJECT: The project name, used to as the work directory of the hardware
+# library during analysis
+ifndef PROJECT
+$(error $(shell echo -e "$(RED)BSG MAKE ERROR: PROJECT is not defined$(NC)"))
+endif
+
 # -------------------- Arguments --------------------
 # This Makefile has several optional "arguments" that are passed as Variables
 #


### PR DESCRIPTION
simlibs.mk requires PROJECT to be set, but it was checked. This is now fixed. 

This PR addresses #421 