### PR TITLE
Vivado 2019.1 support / AWS-FPGA v1.4.11

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -22,10 +22,11 @@ This directory contains the following files:
     3. Implements (places & routes) the RTL Design
     4. Creates a Design Checkpoint (DCP) file
     5. Collects all design files and the final DCP in a tarball (.tar)
-- `create_dcp.tcl`: TCL script responsible for creating the DCP file that is required by Amazon.
-- `synth.tcl`: Synthesis commands for Vivado
-    - Reads all verilog files copied and encrypted by `encrypt.tcl`
+- `create_dcp.tcl`: TCL script responsible for creating the DCP file that is required by Amazon. You must add all the Xilinx libraries you will use here. Read the comments in the file for more information.
+- `synth.tcl`: Synthesis commands for Vivado. (*NOTE*: Must be edited when upgrading vivado)
+    - Reads all verilog files copied and encrypted by `create_dcp.tcl`. For more information, read the comment block in the file. (*NOTE*: Must be edited when upgrading vivado)
 - `README.md`: This file
+
 
 # Quick-Start
 

--- a/build/create_dcp.tcl
+++ b/build/create_dcp.tcl
@@ -189,6 +189,25 @@ set VIVADO_IP_DIR $::env(XILINX_VIVADO)/data/ip/xilinx/
 set TARGET_DIR $CL_DIR/build/src_post_encryption
 set UNUSED_TEMPLATES_DIR $HDK_SHELL_DIR/design/interfaces
 
+# OK - here, and in synth.tcl is how we handle Xilinx IP in the
+# HDL flow. Things get... a little weird. 
+#
+# The following lines copy the source files of any verilog and VHDL IP
+# that we use in the design. It's ugly, but effective, and I can't
+# figure out how to do it any better. In essence, for every IP that we
+# use, we copy the HDL file from it's xilinx IP directory, into
+# $TARGET_DIR. However, it's not that simple, because each IP can
+# depend on underlying IP -- for example the AXI MM FIFO
+# (axi_fifo_mm_s) uses the Fifo Library (lib_fifo), so you ALSO have
+# to copy the Fifo Library. The only way you can determine what IP
+# files are dependencies is by reading the component.xml file and
+# finding the Verilog/VHDL Synthesis Fileset. Repeat (recursively)
+# until no more IPs remain.
+#
+# As I said, it's janky.
+#
+# If you want to know how the files are used by vivado once they are
+# copied, read synth.tcl.
 file copy -force $VIVADO_IP_DIR/generic_baseblocks_v2_1/hdl/generic_baseblocks_v2_1_vl_rfs.v        $TARGET_DIR
 file copy -force $VIVADO_IP_DIR/axi_register_slice_v2_1/hdl/axi_register_slice_v2_1_vl_rfs.v        $TARGET_DIR
 file copy -force $VIVADO_IP_DIR/axi_crossbar_v2_1/hdl/axi_crossbar_v2_1_vl_rfs.v                    $TARGET_DIR

--- a/build/synth.tcl
+++ b/build/synth.tcl
@@ -44,12 +44,12 @@ puts "AWS FPGA: ([clock format [clock seconds] -format %T]) Reading developer's 
 
 read_verilog -sv [glob $ENC_SRC_DIR/*.{v,sv,vh}]
 
-read_vhdl -library axi_fifo_mm_s_v4_1_14 $ENC_SRC_DIR/axi_fifo_mm_s_v4_1_rfs.vhd
+read_vhdl -library axi_fifo_mm_s_v4_1_16 $ENC_SRC_DIR/axi_fifo_mm_s_v4_1_rfs.vhd
 read_vhdl -library lib_pkg_v1_0_2 $ENC_SRC_DIR/lib_pkg_v1_0_rfs.vhd
 read_vhdl -library axi_lite_ipif_v3_0_4 $ENC_SRC_DIR/axi_lite_ipif_v3_0_vh_rfs.vhd
-read_vhdl -library fifo_generator_v13_2_2 $ENC_SRC_DIR/fifo_generator_v13_2_vhsyn_rfs.vhd
-read_vhdl -library blk_mem_gen_v8_4_1 $ENC_SRC_DIR/blk_mem_gen_v8_4_vhsyn_rfs.vhd
-read_vhdl -library lib_fifo_v1_0_11 $ENC_SRC_DIR/lib_fifo_v1_0_rfs.vhd
+read_vhdl -library fifo_generator_v13_2_4 $ENC_SRC_DIR/fifo_generator_v13_2_vhsyn_rfs.vhd
+read_vhdl -library blk_mem_gen_v8_4_3 $ENC_SRC_DIR/blk_mem_gen_v8_4_vhsyn_rfs.vhd
+read_vhdl -library lib_fifo_v1_0_13 $ENC_SRC_DIR/lib_fifo_v1_0_rfs.vhd
 
 set_param synth.elaboration.rodinMoreOptions "rt::set_parameter var_size_limit 4194304"
 

--- a/build/synth.tcl
+++ b/build/synth.tcl
@@ -44,6 +44,18 @@ puts "AWS FPGA: ([clock format [clock seconds] -format %T]) Reading developer's 
 
 read_verilog -sv [glob $ENC_SRC_DIR/*.{v,sv,vh}]
 
+# OK - here, and in create_dcp.tcl is how we handle Xilinx IP in the
+# HDL flow. Things get... a little weird. The following lines read in
+# VHDL libraries from the VHDL files specified. Every time that Vivado
+# is upgraded (e.g. 2018.2 to 2019.1) you need to check/update the
+# version numbers (e.g. axi_fifo_mm_s_v4_1_14 will become
+# axi_fifo_mm_s_v4_1_16). The only way I've figured out how to do this
+# is by reading the component.xml file in the corresponding IP
+# directory of the Xilinx IP Library
+# (e.g. Vivado/2019.2/data/ip/xilinx/axi_fifo_mm_s_v4_1/component.xml). 
+#
+# But how do the files get copied to $ENC_SRC_DIR? Read create_dcp.tcl.
+
 read_vhdl -library axi_fifo_mm_s_v4_1_16 $ENC_SRC_DIR/axi_fifo_mm_s_v4_1_rfs.vhd
 read_vhdl -library fifo_generator_v13_2_4 $ENC_SRC_DIR/fifo_generator_v13_2_vhsyn_rfs.vhd
 read_vhdl -library lib_fifo_v1_0_13 $ENC_SRC_DIR/lib_fifo_v1_0_rfs.vhd

--- a/build/synth.tcl
+++ b/build/synth.tcl
@@ -45,11 +45,11 @@ puts "AWS FPGA: ([clock format [clock seconds] -format %T]) Reading developer's 
 read_verilog -sv [glob $ENC_SRC_DIR/*.{v,sv,vh}]
 
 read_vhdl -library axi_fifo_mm_s_v4_1_16 $ENC_SRC_DIR/axi_fifo_mm_s_v4_1_rfs.vhd
+read_vhdl -library fifo_generator_v13_2_4 $ENC_SRC_DIR/fifo_generator_v13_2_vhsyn_rfs.vhd
+read_vhdl -library lib_fifo_v1_0_13 $ENC_SRC_DIR/lib_fifo_v1_0_rfs.vhd
 read_vhdl -library lib_pkg_v1_0_2 $ENC_SRC_DIR/lib_pkg_v1_0_rfs.vhd
 read_vhdl -library axi_lite_ipif_v3_0_4 $ENC_SRC_DIR/axi_lite_ipif_v3_0_vh_rfs.vhd
-read_vhdl -library fifo_generator_v13_2_4 $ENC_SRC_DIR/fifo_generator_v13_2_vhsyn_rfs.vhd
 read_vhdl -library blk_mem_gen_v8_4_3 $ENC_SRC_DIR/blk_mem_gen_v8_4_vhsyn_rfs.vhd
-read_vhdl -library lib_fifo_v1_0_13 $ENC_SRC_DIR/lib_fifo_v1_0_rfs.vhd
 
 set_param synth.elaboration.rodinMoreOptions "rt::set_parameter var_size_limit 4194304"
 

--- a/build/synth.tcl
+++ b/build/synth.tcl
@@ -67,6 +67,7 @@ set_param synth.elaboration.rodinMoreOptions "rt::set_parameter var_size_limit 4
 
 set_property file_type "Verilog Header" [get_files $ENC_SRC_DIR/bsg_defines.v]
 set_property is_global_include true [get_files $ENC_SRC_DIR/bsg_defines.v]
+set_property XPM_LIBRARIES {XPM_FIFO} [current_project]
 
 #---- End of section replaced by User ----
 

--- a/hardware/axil_to_mcl.v
+++ b/hardware/axil_to_mcl.v
@@ -140,7 +140,7 @@ module axil_to_mcl
    end
   // synopsys translate_on
 
-  axi_crossbar_v2_1_18_axi_crossbar #(
+  axi_crossbar_v2_1_20_axi_crossbar #(
     .C_FAMILY                   ("virtexuplus"             )
     ,.C_NUM_SLAVE_SLOTS          (1                         )
     ,.C_NUM_MASTER_SLOTS         (C_NUM_MASTER_SLOTS        )

--- a/hardware/s_axil_mcl_adapter.v
+++ b/hardware/s_axil_mcl_adapter.v
@@ -98,9 +98,9 @@ axi_fifo_mm_s #(
   .C_TX_FIFO_DEPTH       (512           ),
   .C_RX_FIFO_DEPTH       (512           ),
   .C_TX_FIFO_PF_THRESHOLD(507           ),
-  .C_TX_FIFO_PE_THRESHOLD(2             ),
+  .C_TX_FIFO_PE_THRESHOLD(5             ),
   .C_RX_FIFO_PF_THRESHOLD(507           ),
-  .C_RX_FIFO_PE_THRESHOLD(2             ),
+  .C_RX_FIFO_PE_THRESHOLD(5             ),
   .C_USE_TX_CUT_THROUGH  (0             ),
   .C_DATA_INTERFACE_TYPE (0             ),
   .C_BASEADDR            (32'h80000000  ),
@@ -193,7 +193,7 @@ axi_fifo_mm_s #(
                    );
 */
 
-axis_dwidth_converter_v1_1_16_axis_dwidth_converter #(
+axis_dwidth_converter_v1_1_18_axis_dwidth_converter #(
   .C_FAMILY(fpga_version_p),
   .C_S_AXIS_TDATA_WIDTH(32),
   .C_M_AXIS_TDATA_WIDTH(mcl_width_p),
@@ -285,7 +285,7 @@ bsg_fifo_1r1w_small #(
   ,.yumi_i (rcv_fifo_yumi_li)
 );
 
-axis_dwidth_converter_v1_1_16_axis_dwidth_converter #(
+axis_dwidth_converter_v1_1_18_axis_dwidth_converter #(
   .C_FAMILY            (fpga_version_p                    ),
   .C_S_AXIS_TDATA_WIDTH(mcl_width_p                       ),
   .C_M_AXIS_TDATA_WIDTH(32                                ),

--- a/scripts/amibuild/build.py
+++ b/scripts/amibuild/build.py
@@ -61,7 +61,7 @@ args = parser.parse_args()
 timestamp = datetime.datetime.now().strftime('%Y/%m/%d-%H:%M:%S')
 instance_name = 'v' + args.ImageVersion + ' ' + timestamp + '_image_build'
 ami_name = 'BSG ' + args.Name[0] + ' v' + args.ImageVersion + ' AMI ' 
-base_ami = 'ami-093cf634bf32a0b7e'
+base_ami = 'ami-0748b65979d146c04'
 # The instance type is used to build the image - it does not need to match the
 # final instance type (e.g. an F1 instance type)
 instance_type = 't2.2xlarge'


### PR DESCRIPTION
There are a few changes here. 

* Documentation (in case we need to upgrade Vivado again in the future)
* IP Version Numbers (See Documentation)
* The Base AMI used by amibuild (to reflect 2019.1 AMI)