### PR TITLE
Add support for e_mem_cfg_f1_dram

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,27 +65,17 @@ regression:
 
 # DEBUG=1 Opens the Waveform GUI during simulation
 
-# AXI_PROT_CHECK=1 enables an AXI Protocol Checker on the PCI
-# Interface of the AWS Shell
-
-# AXI_MEMORY_MODEL=0 directs simulation to use the slower, but more
-# accurate, DDR Model.
-
 # TURBO=1 increases simulation speed, but disables waveform generation
 
 # EXTRA_TURBO=1 further increases simulation speed, but may affect
 # correctness.
 DEBUG ?=
-AXI_MEMORY_MODEL ?= 1
-AXI_PROT_CHECK ?=
 TURBO ?= 1 
 EXTRA_TURBO ?= 0
 
 cosim: 
 	$(MAKE) -C testbenches regression DEBUG=$(DEBUG)	\
-		AXI_MEMORY_MODEL=$(AXI_MEMORY_MODEL)		\
-		AXI_PROT_CHECK=$(AXI_PROT_CHECK) TURBO=$(TURBO)	\
-		EXTRA_TURBO=$(EXTRA_TURBO)
+		TURBO=$(TURBO) EXTRA_TURBO=$(EXTRA_TURBO)
 
 clean:
 	$(MAKE) -C testbenches clean 

--- a/testbenches/Makefile
+++ b/testbenches/Makefile
@@ -55,9 +55,6 @@ include simlibs.mk
 #
 # This Makefile has several optional "arguments" that are passed as Variables
 #
-# AXI_MEMORY_MODEL: Use an SRAM-like Memory model that increases simulation
-#                   speed. Default: 1
-# AXI_PROT_CHECK: Enables PCIe Protocol checker. Default: 0
 # DEBUG: Opens the GUI during cosimulation. Default: 0
 # TURBO: Disables VPD generation. Default: 1
 # EXTRA_TURBO: Disables VPD Generation, and more optimization flags: Default 0
@@ -67,8 +64,6 @@ include simlibs.mk
 # will retain this setting
 
 DEBUG ?= 0
-AXI_MEMORY_MODEL ?= 1
-AXI_PROT_CHECK ?= 0
 TURBO ?= 1 # Use if you don't want debug information
 EXTRA_TURBO ?= 0 # Use at your own risk.
 
@@ -82,8 +77,7 @@ regression: $(TARGETS)
 	@cat $(foreach tgt,$(TARGETS),$(tgt)/regression.log)
 $(TARGETS): $(SIMLIBS)
 	$(MAKE) -C  $@ regression EXTRA_TURBO=$(EXTRA_TURBO) 			\
-		DEBUG=$(DEBUG) AXI_PROT_CHECK=$(AXI_PROT_CHECK) 		\
-		TURBO=$(TURBO) AXI_MEMORY_MODEL=$(AXI_MEMORY_MODEL)
+		DEBUG=$(DEBUG) TURBO=$(TURBO)
 
 clean: $(addsuffix .clean,$(TARGETS)) simlibs.clean
 	rm -rf *.log *.jou

--- a/testbenches/cosimulation.mk
+++ b/testbenches/cosimulation.mk
@@ -55,4 +55,4 @@ help:
 	@echo "      clean: Remove all subdirectory-specific outputs"
 
 clean: regression.clean compilation.clean $(USER_CLEAN_RULES)
-	rm -rf vanilla.log vcache_stats.log vanilla_stats.log
+	rm -rf vanilla.log vcache_stats.log vanilla_stats.log vanilla_stall_trace.log

--- a/testbenches/simlibs.mk
+++ b/testbenches/simlibs.mk
@@ -32,8 +32,7 @@ RED=\033[0;31m
 NC=\033[0m
 
 # This file REQUIRES several variables to be set. They are typically
-# set by the Makefile that includes this makefile..
-# 
+# set by the Makefile that includes this makefile.
 
 # CL_DIR: The path to the root of the BSG F1 Repository
 ifndef CL_DIR
@@ -59,17 +58,11 @@ endif
 # -------------------- Arguments --------------------
 # This Makefile has several optional "arguments" that are passed as Variables
 #
-# AXI_MEMORY_MODEL: Use an SRAM-like Memory model that increases simulation
-#                   speed. Default: 1 (Requires re-compilation when changed)
-# AXI_PROT_CHECK: Enables PCIe Protocol checker. Default: 0 (Requires
-#                 re-compilation when changed)
 # EXTRA_TURBO: Disables VPD Generation, and more optimization flags: Default 0
 # 
 # If you need additional speed, you can set EXTRA_TURBO=1 during compilation. 
 # This is a COMPILATION ONLY option. Any subsequent runs, without compilation
 # will retain this setting
-AXI_MEMORY_MODEL ?= 1
-AXI_PROT_CHECK   ?= 0
 EXTRA_TURBO      ?= 0
 
 # The following variables are set by $(CL_DIR)/hdk.mk, which will fail if
@@ -141,7 +134,8 @@ ifeq ($(AXI_PROT_CHECK),1)
 VDEFINES   += ENABLE_PROTOCOL_CHK
 endif
 
-ifeq ($(AXI_MEMORY_MODEL),1)
+include $(CL_DIR)/Makefile.machine.include
+ifneq ($(CL_MANYCORE_MEM_CFG),e_mem_cfg_f1_dram)
 VDEFINES   += AXI_MEMORY_MODEL=1
 VDEFINES   += ECC_DIRECT_EN
 VDEFINES   += RND_ECC_EN

--- a/testbenches/simlibs.mk
+++ b/testbenches/simlibs.mk
@@ -135,6 +135,10 @@ VDEFINES   += ENABLE_PROTOCOL_CHK
 endif
 
 include $(CL_DIR)/Makefile.machine.include
+# Setting CL_MANYCORE_MEM_CFG to e_mem_cfg_f1_dram directs simulation
+# to use the slower, but more accurate, DDR Model. The default is
+# e_mem_cfg_default which uses an (infinite) AXI memory model with low
+# (1-2 cycle) latency.
 ifneq ($(CL_MANYCORE_MEM_CFG),e_mem_cfg_f1_dram)
 VDEFINES   += AXI_MEMORY_MODEL=1
 VDEFINES   += ECC_DIRECT_EN


### PR DESCRIPTION
This enum value switches between the AXI memory model
(e_mem_cfg_default), the infinite vcache memory (e_mem_cfg_infinite)
and the DRAM model provided by F1 (e_mem_cfg_f1_dram). The latter has
the most accurate timing model, but is the slowest to simulate.

This removes the AXI_MEMORY_MODEL Makefile argument

Also removed, AXI_PROT_CHECK (stale)