### PR TITLE
Removed dependence on bsg_manycore_mem_cfg_pkg.v

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,22 +65,17 @@ regression:
 
 # DEBUG=1 Opens the Waveform GUI during simulation
 
-# AXI_PROT_CHECK=1 enables an AXI Protocol Checker on the PCI
-# Interface of the AWS Shell
-
 # TURBO=1 increases simulation speed, but disables waveform generation
 
 # EXTRA_TURBO=1 further increases simulation speed, but may affect
 # correctness.
 DEBUG ?=
-AXI_PROT_CHECK ?=
 TURBO ?= 1 
 EXTRA_TURBO ?= 0
 
 cosim: 
-	$(MAKE) -C testbenches regression DEBUG=$(DEBUG)	\
-		AXI_PROT_CHECK=$(AXI_PROT_CHECK) TURBO=$(TURBO)	\
-		EXTRA_TURBO=$(EXTRA_TURBO)
+	$(MAKE) -C testbenches regression EXTRA_TURBO=$(EXTRA_TURBO)	\
+		DEBUG=$(DEBUG) TURBO=$(TURBO)
 
 clean:
 	$(MAKE) -C testbenches clean 

--- a/Makefile
+++ b/Makefile
@@ -68,22 +68,17 @@ regression:
 # AXI_PROT_CHECK=1 enables an AXI Protocol Checker on the PCI
 # Interface of the AWS Shell
 
-# AXI_MEMORY_MODEL=0 directs simulation to use the slower, but more
-# accurate, DDR Model.
-
 # TURBO=1 increases simulation speed, but disables waveform generation
 
 # EXTRA_TURBO=1 further increases simulation speed, but may affect
 # correctness.
 DEBUG ?=
-AXI_MEMORY_MODEL ?= 1
 AXI_PROT_CHECK ?=
 TURBO ?= 1 
 EXTRA_TURBO ?= 0
 
 cosim: 
 	$(MAKE) -C testbenches regression DEBUG=$(DEBUG)	\
-		AXI_MEMORY_MODEL=$(AXI_MEMORY_MODEL)		\
 		AXI_PROT_CHECK=$(AXI_PROT_CHECK) TURBO=$(TURBO)	\
 		EXTRA_TURBO=$(EXTRA_TURBO)
 

--- a/Makefile.machine.include
+++ b/Makefile.machine.include
@@ -48,5 +48,4 @@ CL_MANYCORE_HOST_COORD_Y             := 0
 CL_MANYCORE_DIM_X                    := $(BSG_MACHINE_GLOBAL_X)
 CL_MANYCORE_DIM_Y                    := $(shell expr $(BSG_MACHINE_GLOBAL_Y) - 1)
 
-CL_MANYCORE_MEM_CFG                  := e_vcache_blocking_axi4_f1_dram
-
+CL_MANYCORE_MEM_CFG                  := e_vcache_blocking_axi4_f1_model

--- a/hardware/bsg_bladerunner_mem_cfg_pkg.v
+++ b/hardware/bsg_bladerunner_mem_cfg_pkg.v
@@ -45,7 +45,16 @@ package bsg_bladerunner_mem_cfg_pkg;
     // LEVEL 1) bsg_manycore_vcache (blocking)
     // LEVEL 2) bsg_cache_to_axi
     // LEVEl 3) bsg_nonsynth_manycore_axi_mem
+
+    // e_vcache_blocking_axi4_f1_dram directs simulation to use the
+    // slower, but more accurate, DDR Model. The default is
+    // e_vcache_blocking_axi4_f1_model uses an (infinite) AXI memory
+    // model with low (1-2 cycle) latency in simulation. 
+    //                                      
+    // Either value produces the correct DDR4 Module in F1
+    // implemenation
     , e_vcache_blocking_axi4_f1_dram
+    , e_vcache_blocking_axi4_f1_model
 
   } bsg_bladerunner_mem_cfg_e;
 

--- a/hardware/bsg_bladerunner_mem_cfg_pkg.v
+++ b/hardware/bsg_bladerunner_mem_cfg_pkg.v
@@ -1,0 +1,53 @@
+/**
+ *  bsg_bladerunner_mem_cfg_pkg.v
+ */
+
+package bsg_bladerunner_mem_cfg_pkg;
+
+  `include "bsg_defines.v"
+
+  localparam max_cfgs = 128;
+  localparam lg_max_cfgs = `BSG_SAFE_CLOG2(max_cfgs); 
+
+  // Bladerunner Memory Configuration enum
+  // 
+  // The enum naming convention describes which memory system is being used.
+  // It roughly divides into three levels of hierarchy.
+  //
+  // e_{cache/block_mem}_{interface}_{backend_memory}
+  //    
+  //
+  // LEVEL 1) What is attached to manycore link on the south side. This could be the
+  //          last level of hierarchy, if it's block mem, or infinite memory, for
+  //          example.
+  //          - e_vcache_blocking_*
+  //          - e_vcache_non_blocking_*
+  //          - e_infinite_memory
+  //
+  // LEVEL 2) What interface does cache DMA interface converts to.
+  //          - dma_ (no interface conversion)
+  //          - axi4_ (convert to axi4)
+  //          - dmc_ (convert to bsg_dmc interface)
+  //          - aib_ (convert to AIB interface)
+  //
+  // LEVEL 3) What is being used as the last main memory.
+  //          - nonsynth_mem 
+  //          - lpddr4 (ex. micron sim model)
+  //          - f1_ddr
+  //
+
+  typedef enum bit [lg_max_cfgs-1:0] {
+
+    // LEVEL 1) zero-latency, infinite capacity block mem.
+    //          (uses associative array)
+    e_infinite_mem
+    
+    // LEVEL 1) bsg_manycore_vcache (blocking)
+    // LEVEL 2) bsg_cache_to_axi
+    // LEVEl 3) bsg_nonsynth_manycore_axi_mem
+    , e_vcache_blocking_axi4_nonsynth_mem
+    , e_vcache_blocking_axi4_f1_dram
+
+  } bsg_bladerunner_mem_cfg_e;
+
+endpackage

--- a/hardware/bsg_bladerunner_mem_cfg_pkg.v
+++ b/hardware/bsg_bladerunner_mem_cfg_pkg.v
@@ -45,7 +45,6 @@ package bsg_bladerunner_mem_cfg_pkg;
     // LEVEL 1) bsg_manycore_vcache (blocking)
     // LEVEL 2) bsg_cache_to_axi
     // LEVEl 3) bsg_nonsynth_manycore_axi_mem
-    , e_vcache_blocking_axi4_nonsynth_mem
     , e_vcache_blocking_axi4_f1_dram
 
   } bsg_bladerunner_mem_cfg_e;

--- a/hardware/cl_manycore.sv
+++ b/hardware/cl_manycore.sv
@@ -417,7 +417,8 @@ module cl_manycore
     );
 
   end
-  else if (mem_cfg_p == e_vcache_blocking_axi4_f1_dram) begin: lv1_vcache
+  else if (mem_cfg_p == e_vcache_blocking_axi4_f1_dram || 
+           mem_cfg_p == e_vcache_blocking_axi4_f1_model) begin: lv1_vcache
 
     import bsg_cache_pkg::*;
 
@@ -484,7 +485,8 @@ module cl_manycore
 
   // LEVEL 2
   //
-  if (mem_cfg_p == e_vcache_blocking_axi4_f1_dram) begin: lv2_axi4
+  if (mem_cfg_p == e_vcache_blocking_axi4_f1_dram || 
+      mem_cfg_p == e_vcache_blocking_axi4_f1_model) begin: lv2_axi4
 
     logic [axi_id_width_p-1:0] axi_awid;
     logic [axi_addr_width_p-1:0] axi_awaddr;
@@ -597,7 +599,8 @@ module cl_manycore
 
   // LEVEL 3
   //
-  if (mem_cfg_p == e_vcache_blocking_axi4_f1_dram) begin
+  if (mem_cfg_p == e_vcache_blocking_axi4_f1_dram ||
+      mem_cfg_p == e_vcache_blocking_axi4_f1_model) begin
    // Attach cache to output DRAM
 
    // AXI Address Write signals

--- a/hardware/cl_manycore.sv
+++ b/hardware/cl_manycore.sv
@@ -34,7 +34,7 @@
 module cl_manycore
   import cl_manycore_pkg::*;
    import bsg_bladerunner_rom_pkg::*;
-   import bsg_manycore_mem_cfg_pkg::*;
+   import bsg_bladerunner_mem_cfg_pkg::*;
    (
 `include "cl_ports.vh"
     );

--- a/hardware/cl_manycore_pkg.v
+++ b/hardware/cl_manycore_pkg.v
@@ -10,9 +10,9 @@ package cl_manycore_pkg;
 
   `include "bsg_defines.v"
   `include "f1_parameters.vh"
-  import bsg_manycore_mem_cfg_pkg::*;
+  import bsg_bladerunner_mem_cfg_pkg::*;
   
-  parameter bsg_manycore_mem_cfg_e mem_cfg_p = `CL_MANYCORE_MEM_CFG;
+  parameter bsg_bladerunner_mem_cfg_e mem_cfg_p = `CL_MANYCORE_MEM_CFG;
   parameter addr_width_p = `CL_MANYCORE_MAX_EPA_WIDTH;
   parameter data_width_p = `CL_MANYCORE_DATA_WIDTH;
   parameter num_tiles_x_p = `CL_MANYCORE_DIM_X;

--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -89,8 +89,7 @@ include $(BSG_MANYCORE_DIR)/machines/arch_filelist.mk
 # but transformed into a tool-specific syntax where necesssary.
 VINCLUDES += $(HARDWARE_PATH)
 
-VHEADERS += $(BSG_MANYCORE_DIR)/testbenches/common/v/bsg_manycore_mem_cfg_pkg.v
-
+VSOURCES += $(HARDWARE_PATH)/bsg_bladerunner_mem_cfg_pkg.v
 VSOURCES += $(HARDWARE_PATH)/bsg_bladerunner_configuration.v
 VSOURCES += $(HARDWARE_PATH)/cl_manycore_pkg.v
 VSOURCES += $(HARDWARE_PATH)/$(CL_TOP_MODULE).sv

--- a/testbenches/Makefile
+++ b/testbenches/Makefile
@@ -55,8 +55,6 @@ include simlibs.mk
 #
 # This Makefile has several optional "arguments" that are passed as Variables
 #
-# AXI_MEMORY_MODEL: Use an SRAM-like Memory model that increases simulation
-#                   speed. Default: 1
 # AXI_PROT_CHECK: Enables PCIe Protocol checker. Default: 0
 # DEBUG: Opens the GUI during cosimulation. Default: 0
 # TURBO: Disables VPD generation. Default: 1
@@ -67,11 +65,9 @@ include simlibs.mk
 # will retain this setting
 
 DEBUG ?= 0
-AXI_MEMORY_MODEL ?= 1
 AXI_PROT_CHECK ?= 0
 TURBO ?= 1 # Use if you don't want debug information
 EXTRA_TURBO ?= 0 # Use at your own risk.
-
 
 # targets.mk defines the targets (sub-directories) for regression in
 # cosimulation
@@ -83,7 +79,7 @@ regression: $(TARGETS)
 $(TARGETS): $(SIMLIBS)
 	$(MAKE) -C  $@ regression EXTRA_TURBO=$(EXTRA_TURBO) 			\
 		DEBUG=$(DEBUG) AXI_PROT_CHECK=$(AXI_PROT_CHECK) 		\
-		TURBO=$(TURBO) AXI_MEMORY_MODEL=$(AXI_MEMORY_MODEL)
+		TURBO=$(TURBO)
 
 clean: $(addsuffix .clean,$(TARGETS)) simlibs.clean
 	rm -rf *.log *.jou

--- a/testbenches/Makefile
+++ b/testbenches/Makefile
@@ -55,7 +55,6 @@ include simlibs.mk
 #
 # This Makefile has several optional "arguments" that are passed as Variables
 #
-# AXI_PROT_CHECK: Enables PCIe Protocol checker. Default: 0
 # DEBUG: Opens the GUI during cosimulation. Default: 0
 # TURBO: Disables VPD generation. Default: 1
 # EXTRA_TURBO: Disables VPD Generation, and more optimization flags: Default 0
@@ -65,7 +64,6 @@ include simlibs.mk
 # will retain this setting
 
 DEBUG ?= 0
-AXI_PROT_CHECK ?= 0
 TURBO ?= 1 # Use if you don't want debug information
 EXTRA_TURBO ?= 0 # Use at your own risk.
 
@@ -77,9 +75,8 @@ include $(REGRESSION_PATH)/targets.mk
 regression: $(TARGETS)
 	@cat $(foreach tgt,$(TARGETS),$(tgt)/regression.log)
 $(TARGETS): $(SIMLIBS)
-	$(MAKE) -C  $@ regression EXTRA_TURBO=$(EXTRA_TURBO) 			\
-		DEBUG=$(DEBUG) AXI_PROT_CHECK=$(AXI_PROT_CHECK) 		\
-		TURBO=$(TURBO)
+	$(MAKE) -C $@ regression EXTRA_TURBO=$(EXTRA_TURBO)	\
+		DEBUG=$(DEBUG) TURBO=$(TURBO)
 
 clean: $(addsuffix .clean,$(TARGETS)) simlibs.clean
 	rm -rf *.log *.jou

--- a/testbenches/simlibs.mk
+++ b/testbenches/simlibs.mk
@@ -59,8 +59,6 @@ endif
 # -------------------- Arguments --------------------
 # This Makefile has several optional "arguments" that are passed as Variables
 #
-# AXI_MEMORY_MODEL: Use an SRAM-like Memory model that increases simulation
-#                   speed. Default: 1 (Requires re-compilation when changed)
 # AXI_PROT_CHECK: Enables PCIe Protocol checker. Default: 0 (Requires
 #                 re-compilation when changed)
 # EXTRA_TURBO: Disables VPD Generation, and more optimization flags: Default 0
@@ -68,7 +66,6 @@ endif
 # If you need additional speed, you can set EXTRA_TURBO=1 during compilation. 
 # This is a COMPILATION ONLY option. Any subsequent runs, without compilation
 # will retain this setting
-AXI_MEMORY_MODEL ?= 1
 AXI_PROT_CHECK   ?= 0
 EXTRA_TURBO      ?= 0
 
@@ -148,7 +145,13 @@ ifeq ($(AXI_PROT_CHECK),1)
 VDEFINES   += ENABLE_PROTOCOL_CHK
 endif
 
-ifeq ($(AXI_MEMORY_MODEL),1)
+include $(CL_DIR)/Makefile.machine.include
+# Setting CL_MANYCORE_MEM_CFG to e_vcache_blocking_axi4_f1_dram
+# directs simulation to use the slower, but more accurate, DDR
+# Model. The default is e_vcache_blocking_axi4_f1_model uses an
+# (infinite) AXI memory model with low (1-2 cycle) latency in
+# simulation.
+ifeq ($(CL_MANYCORE_MEM_CFG),e_vcache_blocking_axi4_f1_model)
 VDEFINES   += AXI_MEMORY_MODEL=1
 VDEFINES   += ECC_DIRECT_EN
 VDEFINES   += RND_ECC_EN

--- a/testbenches/simlibs.mk
+++ b/testbenches/simlibs.mk
@@ -59,14 +59,11 @@ endif
 # -------------------- Arguments --------------------
 # This Makefile has several optional "arguments" that are passed as Variables
 #
-# AXI_PROT_CHECK: Enables PCIe Protocol checker. Default: 0 (Requires
-#                 re-compilation when changed)
 # EXTRA_TURBO: Disables VPD Generation, and more optimization flags: Default 0
 # 
 # If you need additional speed, you can set EXTRA_TURBO=1 during compilation. 
 # This is a COMPILATION ONLY option. Any subsequent runs, without compilation
 # will retain this setting
-AXI_PROT_CHECK   ?= 0
 EXTRA_TURBO      ?= 0
 
 # The following variables are set by $(CL_DIR)/hdk.mk, which will fail if
@@ -140,10 +137,7 @@ WORKDIR = $(TESTBENCH_PATH)/vcs_simlibs/$(PROJECT)
 VDEFINES   += VCS_SIM
 VDEFINES   += COSIM
 VDEFINES   += DISABLE_VJTAG_DEBUG
-
-ifeq ($(AXI_PROT_CHECK),1)
 VDEFINES   += ENABLE_PROTOCOL_CHK
-endif
 
 include $(CL_DIR)/Makefile.machine.include
 # Setting CL_MANYCORE_MEM_CFG to e_vcache_blocking_axi4_f1_dram


### PR DESCRIPTION
Sorry - this was a specific feedback on my original PR (#438, and corresponding PR #184 in Manycore). 

We don't want to have F1-specific features in bsg_manycore. I didn't communicate this very well, but our goal is to have a bsg_bladerunner_mem_cfg_pkg that defines all the memory types that bladerunner supports in simulation