### PR TITLE
Removed Makefile.machines.include from tests.mk

### DIFF
--- a/regression/cuda/tests.mk
+++ b/regression/cuda/tests.mk
@@ -28,10 +28,6 @@
 # This Makefile fragment defines all of the regression tests (and the
 # source path) for this sub-directory.
 
-# Makefile.machine.include defines the Manycore hardware
-# configuration.
-include $(CL_DIR)/Makefile.machine.include
-
 REGRESSION_TESTS_TYPE = cuda
 SRC_PATH=$(REGRESSION_PATH)/$(REGRESSION_TESTS_TYPE)/
 

--- a/regression/library/tests.mk
+++ b/regression/library/tests.mk
@@ -28,10 +28,6 @@
 # This Makefile fragment defines all of the regression tests (and the
 # source path) for this sub-directory.
 
-# Makefile.machine.include defines the Manycore hardware
-# configuration.
-include $(CL_DIR)/Makefile.machine.include
-
 REGRESSION_TESTS_TYPE = library
 SRC_PATH=$(REGRESSION_PATH)/$(REGRESSION_TESTS_TYPE)/
 

--- a/regression/python/tests.mk
+++ b/regression/python/tests.mk
@@ -28,10 +28,6 @@
 # This Makefile fragment defines all of the regression tests (and the
 # source path) for this sub-directory.
 
-# Makefile.machine.include defines the Manycore hardware
-# configuration.
-include $(CL_DIR)/Makefile.machine.include
-
 REGRESSION_TESTS_TYPE = python
 SRC_PATH=$(REGRESSION_PATH)/$(REGRESSION_TESTS_TYPE)/
 

--- a/regression/specint/tests.mk
+++ b/regression/specint/tests.mk
@@ -28,10 +28,6 @@
 # This Makefile fragment defines all of the regression tests (and the
 # source path) for this sub-directory.
 
-# Makefile.machine.include defines the Manycore hardware
-# configuration.
-include $(CL_DIR)/Makefile.machine.include
-
 REGRESSION_TESTS_TYPE = specint
 SRC_PATH=$(REGRESSION_PATH)/$(REGRESSION_TESTS_TYPE)
 

--- a/regression/spmd/tests.mk
+++ b/regression/spmd/tests.mk
@@ -28,10 +28,6 @@
 # This Makefile fragment defines all of the regression tests (and the
 # source path) for this sub-directory.
 
-# Makefile.machine.include defines the Manycore hardware
-# configuration.
-include $(CL_DIR)/Makefile.machine.include
-
 REGRESSION_TESTS_TYPE = spmd
 SRC_PATH=$(REGRESSION_PATH)/$(REGRESSION_TESTS_TYPE)/
 


### PR DESCRIPTION
No makefile that includes tests.mk needs the variables defined in
Makefile.machines.include