### PR TITLE
Re-implemented BSG Time to use $time, instead of $realtime

### DIFF
--- a/libraries/bsg_manycore_printing.cpp
+++ b/libraries/bsg_manycore_printing.cpp
@@ -48,7 +48,7 @@ static void insert_time(prefix_info_t *info, const char *prefix)
         /* insert time here */
 #if 1
 #ifdef COSIM
-        fprintf(info->file, "%s @ (%llu/%llu): ", prefix, bsg_realtime(), bsg_utc());
+        fprintf(info->file, "%s @ (%llu/%llu): ", prefix, bsg_time(), bsg_utc());
 #else
         fprintf(info->file, "%s @ (%llu): ", prefix, bsg_utc());
 #endif
@@ -135,10 +135,9 @@ int bsg_pr_prefix(const char *prefix, const char *fmt, ...)
         return r;
 }
 #ifdef COSIM
-uint64_t bsg_realtime(){
+uint64_t bsg_time(){
         uint64_t val;
-        //fprintf(stderr,"%s()\n", __func__);
-        sv_bsg_realtime(&val);
+        sv_bsg_time(&val);
         return val;
 }
 #endif

--- a/libraries/bsg_manycore_printing.h
+++ b/libraries/bsg_manycore_printing.h
@@ -59,8 +59,8 @@ extern "C" {
 #define BSG_PRINT_STREAM_INFO  stderr
 
 #ifdef COSIM
-        extern void sv_bsg_realtime(uint64_t*);
-        uint64_t bsg_realtime();
+        extern void sv_bsg_time(uint64_t*);
+        uint64_t bsg_time();
 #endif
 
         static inline uint64_t bsg_utc(){
@@ -79,7 +79,7 @@ extern "C" {
 
         /* #if defined(DEBUG) && defined(COSIM) */
         /* #define bsg_pr_dbg(fmt, ...)                    \ */
-        /*         bsg_pr_prefix(BSG_PRINT_PREFIX_DEBUG, fmt, bsg_realtime(), bsg_utc(), ##__VA_ARGS__) */
+        /*         bsg_pr_prefix(BSG_PRINT_PREFIX_DEBUG, fmt, bsg_time(), bsg_utc(), ##__VA_ARGS__) */
         /* #elif defined(DEBUG) */
         /* #define bsg_pr_dbg(fmt, ...)                    \ */
         /*         bsg_pr_prefix(BSG_PRINT_PREFIX_DEBUG, fmt, bsg_utc(), ##__VA_ARGS__) */

--- a/testbenches/sh_dpi_tasks.svh
+++ b/testbenches/sh_dpi_tasks.svh
@@ -44,9 +44,10 @@ import tb_type_defines_pkg::*;
    static int h2c_desc_index = 0;
    static int c2h_desc_index = 0;
    
-   export "DPI-C" task sv_bsg_realtime;
-   task sv_bsg_realtime(output longint unsigned t);
-       t = $realtime;
+   export "DPI-C" task sv_bsg_time;
+
+   task sv_bsg_time(output longint unsigned t);
+      t = $time;
    endtask
 
    task sv_printf(input string msg);


### PR DESCRIPTION
This makes it consistent with BSG Manycore, when reporting time values in simulation