### PR TITLE
Renamed hb_mc_application_init to hb_mc_kernel_enqueue 

### DIFF
--- a/libraries/bsg_manycore_cuda.cpp
+++ b/libraries/bsg_manycore_cuda.cpp
@@ -288,7 +288,7 @@ static int hb_mc_device_mesh_exit (hb_mc_mesh_t *mesh) {
 
 
 /**
- * Enqueues and schedules an application to be run on device
+ * Enqueues and schedules a kernel to be run on device
  * Takes the grid size, tile group dimensions, kernel name, argc, argv* and the
  * finish signal address, calls hb_mc_tile_group_enqueue to initialize all tile groups for grid.
  * @param[in]  device        Pointer to device
@@ -299,12 +299,12 @@ static int hb_mc_device_mesh_exit (hb_mc_mesh_t *mesh) {
  * @param[in]  argv          List of input arguments to kernel
  * @return HB_MC_SUCCESS if succesful. Otherwise an error code is returned.
  */
-int hb_mc_application_init (hb_mc_device_t *device,
-                            hb_mc_dimension_t grid_dim,
-                            hb_mc_dimension_t tg_dim,
-                            const char* name,
-                            uint32_t argc,
-                            const uint32_t *argv) {
+int hb_mc_kernel_enqueue (hb_mc_device_t *device,
+                               hb_mc_dimension_t grid_dim,
+                               hb_mc_dimension_t tg_dim,
+                               const char* name,
+                               uint32_t argc,
+                               const uint32_t *argv) {
         int error; 
         for (hb_mc_idx_t tg_id_x = 0; tg_id_x < hb_mc_dimension_get_x(grid_dim); tg_id_x ++) { 
                 for (hb_mc_idx_t tg_id_y = 0; tg_id_y < hb_mc_dimension_get_y(grid_dim); tg_id_y ++) { 

--- a/libraries/bsg_manycore_cuda.h
+++ b/libraries/bsg_manycore_cuda.h
@@ -283,7 +283,7 @@ extern "C" {
 
 
         /**
-         * Enqueues and schedules an application to be run on device
+         * Enqueues and schedules a kernel to be run on device
          * Takes the grid size, tile group dimensions, kernel name, argc,
          * argv* and the finish signal address, calls hb_mc_tile_group_enqueue
          * to initialize all tile groups for grid.
@@ -296,12 +296,12 @@ extern "C" {
          * @return HB_MC_SUCCESS if succesful. Otherwise an error code is returned.
          */
         __attribute__((warn_unused_result))
-        int hb_mc_application_init (hb_mc_device_t *device,
-                                    hb_mc_dimension_t grid_dim,
-                                    hb_mc_dimension_t tg_dim,
-                                    const char *name,
-                                    const uint32_t argc,
-                                    const uint32_t *argv);
+        int hb_mc_kernel_enqueue (hb_mc_device_t *device,
+                                       hb_mc_dimension_t grid_dim,
+                                       hb_mc_dimension_t tg_dim,
+                                       const char *name,
+                                       const uint32_t argc,
+                                       const uint32_t *argv);
 
 
 

--- a/regression/cuda/test_binary_load_buffer.c
+++ b/regression/cuda/test_binary_load_buffer.c
@@ -116,7 +116,7 @@ int kernel_binary_load_buffer(int argc, char **argv) {
         /* Enquque grid of tile groups, pass in grid and tile group dimensions*/
         /* kernel name, number and list of input arguments                    */
         /**********************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_binary_load_buffer", 0, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_binary_load_buffer", 0, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_device_memcpy.c
+++ b/regression/cuda/test_device_memcpy.c
@@ -146,7 +146,7 @@ int kernel_device_memcpy (int argc, char **argv) {
         /* Enquque grid of tile groups, pass in grid and tile group dimensions*/
         /* kernel name, number and list of input arguments                    */
         /**********************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_device_memcpy", 3, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_device_memcpy", 3, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_device_memset.c
+++ b/regression/cuda/test_device_memset.c
@@ -117,7 +117,7 @@ int kernel_device_memset (int argc, char **argv) {
         /* Enquque grid of tile groups, pass in grid and tile group dimensions*/
         /* kernel name, number and list of input arguments                    */
         /**********************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_device_memset", 3, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_device_memset", 3, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_dram_device_allocated.c
+++ b/regression/cuda/test_dram_device_allocated.c
@@ -111,7 +111,7 @@ int kernel_dram_device_allocated (int argc, char **argv) {
         /* Enquque grid of tile groups, pass in grid and tile group dimensions*/
         /* kernel name, number and list of input arguments                    */
         /**********************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_dram_device_allocated", 2, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_dram_device_allocated", 2, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_dram_host_allocated.c
+++ b/regression/cuda/test_dram_host_allocated.c
@@ -108,7 +108,7 @@ int kernel_dram_host_allocated (int argc, char **argv) {
         /* Enquque grid of tile groups, pass in grid and tile group dimensions*/
         /* kernel name, number and list of input arguments                    */
         /**********************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_dram_host_allocated", 1, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_dram_host_allocated", 1, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_empty_parallel.c
+++ b/regression/cuda/test_empty_parallel.c
@@ -83,7 +83,7 @@ int kernel_empty_parallel (int argc, char **argv) {
         /*****************************************************************************************************************
         * Enquque grid of tile groups, pass in grid and tile group dimensions, kernel name, number and list of input arguments
         ******************************************************************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_empty", 0, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_empty", 0, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_float_all_ops.c
+++ b/regression/cuda/test_float_all_ops.c
@@ -293,7 +293,7 @@ int kernel_float_all_ops (int argc, char **argv) {
         /* Enquque grid of tile groups, pass in grid and tile group dimensions*/
         /* kernel name, number and list of input arguments                    */
         /**********************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_float_all_ops", 10, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_float_all_ops", 10, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_float_matrix_mul.c
+++ b/regression/cuda/test_float_matrix_mul.c
@@ -193,7 +193,7 @@ int kernel_float_matrix_mul (int argc, char **argv) {
         /* Enquque grid of tile groups, pass in grid and tile group dimensions*/
         /* kernel name, number and list of input arguments                    */
         /**********************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_float_matrix_mul", 8, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_float_matrix_mul", 8, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_float_matrix_mul_shared_mem.c
+++ b/regression/cuda/test_float_matrix_mul_shared_mem.c
@@ -194,7 +194,7 @@ int kernel_float_matrix_mul_shared_mem (int argc, char **argv) {
         /* Enquque grid of tile groups, pass in grid and tile group dimensions*/
         /* kernel name, number and list of input arguments                    */
         /**********************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_float_matrix_mul_shared_mem", 8, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_float_matrix_mul_shared_mem", 8, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_float_vec_add.c
+++ b/regression/cuda/test_float_vec_add.c
@@ -175,7 +175,7 @@ int kernel_float_vec_add (int argc, char **argv) {
         /* Enquque grid of tile groups, pass in grid and tile group dimensions*/
         /* kernel name, number and list of input arguments                    */
         /**********************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_float_vec_add", 5, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_float_vec_add", 5, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_float_vec_add_shared_mem.c
+++ b/regression/cuda/test_float_vec_add_shared_mem.c
@@ -174,7 +174,7 @@ int kernel_float_vec_add_shared_mem (int argc, char **argv) {
         /* Enquque grid of tile groups, pass in grid and tile group dimensions*/
         /* kernel name, number and list of input arguments                    */
         /**********************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_float_vec_add_shared_mem", 5, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_float_vec_add_shared_mem", 5, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_float_vec_div.c
+++ b/regression/cuda/test_float_vec_div.c
@@ -174,7 +174,7 @@ int kernel_float_vec_div (int argc, char **argv) {
         /* Enquque grid of tile groups, pass in grid and tile group dimensions*/
         /* kernel name, number and list of input arguments                    */
         /**********************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_float_vec_div", 5, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_float_vec_div", 5, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_float_vec_exp.c
+++ b/regression/cuda/test_float_vec_exp.c
@@ -156,7 +156,7 @@ int kernel_float_vec_exp (int argc, char **argv) {
         /* Enquque grid of tile groups, pass in grid and tile group dimensions*/
         /* kernel name, number and list of input arguments                    */
         /**********************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_float_vec_exp", 4, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_float_vec_exp", 4, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_float_vec_log.c
+++ b/regression/cuda/test_float_vec_log.c
@@ -158,7 +158,7 @@ int kernel_float_vec_log (int argc, char **argv) {
         /* Enquque grid of tile groups, pass in grid and tile group dimensions*/
         /* kernel name, number and list of input arguments                    */
         /**********************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_float_vec_log", 4, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_float_vec_log", 4, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_float_vec_mul.c
+++ b/regression/cuda/test_float_vec_mul.c
@@ -175,7 +175,7 @@ int kernel_float_vec_mul (int argc, char **argv) {
         /* Enquque grid of tile groups, pass in grid and tile group dimensions*/
         /* kernel name, number and list of input arguments                    */
         /**********************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_float_vec_mul", 5, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_float_vec_mul", 5, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_float_vec_sqrt.c
+++ b/regression/cuda/test_float_vec_sqrt.c
@@ -156,7 +156,7 @@ int kernel_float_vec_sqrt (int argc, char **argv) {
         /* Enquque grid of tile groups, pass in grid and tile group dimensions*/
         /* kernel name, number and list of input arguments                    */
         /**********************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_float_vec_sqrt", 4, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_float_vec_sqrt", 4, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_host_memset.c
+++ b/regression/cuda/test_host_memset.c
@@ -105,7 +105,7 @@ int kernel_host_memset (int argc, char **argv) {
         /*****************************************************************************************************************
         * Enquque grid of tile groups, pass in grid and tile group dimensions, kernel name, number and list of input arguments
         ******************************************************************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_host_memset", 0, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_host_memset", 0, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_loader.c
+++ b/regression/cuda/test_loader.c
@@ -83,7 +83,7 @@ int test_loader (int argc, char **argv) {
         /* Enquque grid of tile groups, pass in grid and tile group dimensions*/
         /* kernel name, number and list of input arguments                    */
         /**********************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, kernel_name, 0, kernel_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, kernel_name, 0, kernel_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_log_softmax.c
+++ b/regression/cuda/test_log_softmax.c
@@ -113,7 +113,7 @@ int kernel_log_softmax(int argc, char **argv)
 
         int cuda_argv[] = { A_device, B_device, M, N, block_size_y, block_size_x };
         size_t cuda_argc = sizeof(cuda_argv) / sizeof(cuda_argv[0]);
-        rc = hb_mc_application_init(mc, grid_dim, tilegroup_dim, "kernel_log_softmax", cuda_argc, cuda_argv);
+        rc = hb_mc_kernel_enqueue(mc, grid_dim, tilegroup_dim, "kernel_log_softmax", cuda_argc, cuda_argv);
         if(rc != HB_MC_SUCCESS)
         {
                 bsg_pr_err("Failed to initialize grid.\n");

--- a/regression/cuda/test_matrix_mul.c
+++ b/regression/cuda/test_matrix_mul.c
@@ -177,7 +177,7 @@ int kernel_matrix_mul (int argc, char **argv) {
         /*****************************************************************************************************************
         * Enquque grid of tile groups, pass in grid and tile group dimensions, kernel name, number and list of input arguments
         ******************************************************************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_matrix_mul", 8, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_matrix_mul", 8, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_matrix_mul_shared_mem.c
+++ b/regression/cuda/test_matrix_mul_shared_mem.c
@@ -176,7 +176,7 @@ int kernel_matrix_mul_shared_mem (int argc, char **argv) {
         /*****************************************************************************************************************
         * Enquque grid of tile groups, pass in grid and tile group dimensions, kernel name, number and list of input arguments
         ******************************************************************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_matrix_mul_shared_mem", 8, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_matrix_mul_shared_mem", 8, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_max_pool2d.c
+++ b/regression/cuda/test_max_pool2d.c
@@ -191,7 +191,7 @@ int kernel_max_pool2d(int argc, char **argv) {
         /* Enquque grid of tile groups, pass in grid and tile group dimensions*/
         /* kernel name, number and list of input arguments                    */
         /**********************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_max_pool2d", 8, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_max_pool2d", 8, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_multiple_binary_load.c
+++ b/regression/cuda/test_multiple_binary_load.c
@@ -84,7 +84,7 @@ int kernel_multiple_binary_load (int argc, char **argv) {
         /*****************************************************************************************************************
         * Enquque grid of tile groups, pass in grid and tile group dimensions, kernel name, number and list of input arguments
         ******************************************************************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_empty", 0, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_empty", 0, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;
@@ -149,7 +149,7 @@ int kernel_multiple_binary_load (int argc, char **argv) {
         /*****************************************************************************************************************
         * Enquque grid of tile groups, pass in grid and tile group dimensions, kernel name, number and list of input arguments
         ******************************************************************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_empty", 0, argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_empty", 0, argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_shared_mem.c
+++ b/regression/cuda/test_shared_mem.c
@@ -99,7 +99,7 @@ int kernel_shared_mem (int argc, char **argv) {
         /*****************************************************************************************************************
         * Enquque grid of tile groups, pass in grid and tile group dimensions, kernel name, number and list of input arguments
         ******************************************************************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_shared_mem", 2, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_shared_mem", 2, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_shared_mem_load_store.c
+++ b/regression/cuda/test_shared_mem_load_store.c
@@ -133,7 +133,7 @@ int kernel_shared_mem_load_store (int argc, char **argv) {
         /*****************************************************************************************************************
         * Enquque grid of tile groups, pass in grid and tile group dimensions, kernel name, number and list of input arguments
         ******************************************************************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_shared_mem_load_store", 6, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_shared_mem_load_store", 6, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_softmax.c
+++ b/regression/cuda/test_softmax.c
@@ -115,7 +115,7 @@ int kernel_softmax(int argc, char **argv)
 
         int cuda_argv[] = { A_device, B_device, M, N, block_size_y, block_size_x };
         size_t cuda_argc = sizeof(cuda_argv) / sizeof(cuda_argv[0]);
-        rc = hb_mc_application_init(mc, grid_dim, tilegroup_dim, "kernel_softmax", cuda_argc, cuda_argv);
+        rc = hb_mc_kernel_enqueue(mc, grid_dim, tilegroup_dim, "kernel_softmax", cuda_argc, cuda_argv);
         if(rc != HB_MC_SUCCESS)
         {
                 bsg_pr_err("Failed to initialize grid.\n");

--- a/regression/cuda/test_stack_load.c
+++ b/regression/cuda/test_stack_load.c
@@ -97,7 +97,7 @@ int kernel_stack_load (int argc, char **argv) {
         /*****************************************************************************************************************
         * Enquque grid of tile groups, pass in grid and tile group dimensions, kernel name, number and list of input arguments
         ******************************************************************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_stack_load", NUM_ARGS + 1, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_stack_load", NUM_ARGS + 1, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_vec_add.c
+++ b/regression/cuda/test_vec_add.c
@@ -155,7 +155,7 @@ int kernel_vec_add (int argc, char **argv) {
         /*****************************************************************************************************************
         * Enquque grid of tile groups, pass in grid and tile group dimensions, kernel name, number and list of input arguments
         ******************************************************************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_vec_add", 5, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_vec_add", 5, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_vec_add_parallel.c
+++ b/regression/cuda/test_vec_add_parallel.c
@@ -156,7 +156,7 @@ int kernel_vec_add_parallel (int argc, char **argv) {
         /*****************************************************************************************************************
         * Enquque grid of tile groups, pass in grid and tile group dimensions, kernel name, number and list of input arguments
         ******************************************************************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_vec_add_parallel", 5, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_vec_add_parallel", 5, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_vec_add_parallel_multi_grid.c
+++ b/regression/cuda/test_vec_add_parallel_multi_grid.c
@@ -222,14 +222,14 @@ int kernel_vec_add_parallel_multi_grid (int argc, char **argv) {
         /*****************************************************************************************************************
         * Enquque grid of tile groups, pass in grid and tile group dimensions, kernel name, number and list of input arguments
         ******************************************************************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim_1, tg_dim_1, "kernel_vec_add_parallel_multi_grid", 5, cuda_argv1);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim_1, tg_dim_1, "kernel_vec_add_parallel_multi_grid", 5, cuda_argv1);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;
         }
 
 
-        rc = hb_mc_application_init (&device, grid_dim_2, tg_dim_2, "kernel_vec_add_parallel_multi_grid", 5, cuda_argv2);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim_2, tg_dim_2, "kernel_vec_add_parallel_multi_grid", 5, cuda_argv2);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_vec_add_serial_multi_grid.c
+++ b/regression/cuda/test_vec_add_serial_multi_grid.c
@@ -222,7 +222,7 @@ int kernel_vec_add_serial_multi_grid (int argc, char **argv) {
         /*****************************************************************************************************************
         * Enquque grid 1 of tile groups, pass in grid and tile group dimensions, kernel name, number and list of input arguments
         ******************************************************************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim_1, tg_dim_1, "kernel_vec_add_serial_multi_grid", 5, cuda_argv1);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim_1, tg_dim_1, "kernel_vec_add_serial_multi_grid", 5, cuda_argv1);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;
@@ -243,7 +243,7 @@ int kernel_vec_add_serial_multi_grid (int argc, char **argv) {
         /*****************************************************************************************************************
         * Enquque grid 2 of tile groups, pass in grid and tile group dimensions, kernel name, number and list of input arguments
         ******************************************************************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim_2, tg_dim_2, "kernel_vec_add_serial_multi_grid", 5, cuda_argv2);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim_2, tg_dim_2, "kernel_vec_add_serial_multi_grid", 5, cuda_argv2);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;

--- a/regression/cuda/test_vec_add_shared_mem.c
+++ b/regression/cuda/test_vec_add_shared_mem.c
@@ -155,7 +155,7 @@ int kernel_vec_add_shared_mem (int argc, char **argv) {
         /*****************************************************************************************************************
         * Enquque grid of tile groups, pass in grid and tile group dimensions, kernel name, number and list of input arguments
         ******************************************************************************************************************/
-        rc = hb_mc_application_init (&device, grid_dim, tg_dim, "kernel_vec_add_shared_mem", 5, cuda_argv);
+        rc = hb_mc_kernel_enqueue (&device, grid_dim, tg_dim, "kernel_vec_add_shared_mem", 5, cuda_argv);
         if (rc != HB_MC_SUCCESS) { 
                 bsg_pr_err("failed to initialize grid.\n");
                 return rc;


### PR DESCRIPTION
In both library code and regression tests to avoid confusion. The function does not initialize any binaries, only enqueues the tile groups in the host to be scheduled for execution once hb_mc_tile_groups_execute is called.
Technically, the function represents a so-called application, comprised of a 2D grid of tile groups, not a singular tile group, so I left the "application" part in the name as is, and did not change it to tile_group_enqueue. With that said, I welcome any suggestions on this and other function names.
Regression tests passed COSIM.
Related to issue #456 .