### PR TITLE
Fix cache regression

### DIFF
--- a/regression/library/test_vcache_flush.c
+++ b/regression/library/test_vcache_flush.c
@@ -160,11 +160,12 @@ int test_vcache_flush() {
         CACHE_LINE_SIZE_WORDS = hb_mc_config_get_vcache_block_words(config);
         CACHE_LINE_SIZE = hb_mc_config_get_vcache_size(config);
 
-        int dram = 0, ndrams = 1;
+        int dram = 0, ndrams = dim_x;
         hb_mc_idx_t dram_coord_y = hb_mc_config_get_dram_y(config);
         hb_mc_idx_t dram_coord_x = -1;
         hb_mc_idx_t dram_xs[dim_x];
-        dram_xs[0] = 0;
+        // set all dram_xs to their unique column id
+        for (hb_mc_idx_t x = 0; x < dim_x; ++x) dram_xs[x] = x;
 
         addr_bitwidth = hb_mc_config_get_network_bitwidth_addr(config);
         addrs[0] = 0;

--- a/regression/library/test_vcache_sequence.c
+++ b/regression/library/test_vcache_sequence.c
@@ -67,24 +67,27 @@ int test_vcache_sequence() {
 
                 for (int i = 0; i < ARRAY_LEN; i ++) { 
                         A_host = rand();
-
-                        hb_mc_npa_t dram_npa = hb_mc_npa (dram_coord, BASE_ADDR + i); 
+                        hb_mc_epa_t dram_epa = BASE_ADDR + i*sizeof(A_host);
+                        hb_mc_npa_t dram_npa = hb_mc_npa (dram_coord, dram_epa); 
 
                         err = hb_mc_manycore_write32(mc, &dram_npa, A_host); 
                         if (err != HB_MC_SUCCESS) {
-                                bsg_pr_err("%s: failed to write A[%d] = %d to DRAM coord(%d,%d) addr %d.\n", __func__, i, A_host, dram_coord_x, dram_coord_y, BASE_ADDR + i);
+                                bsg_pr_err("%s: failed to write A[%d] = %d to DRAM coord(%d,%d) addr 0x%08x.\n",
+                                           __func__, i, A_host, dram_coord_x, dram_coord_y, dram_epa);
                                 return err;
                         }
 
 
                         err = hb_mc_manycore_read32(mc, &dram_npa, &A_device); 
                         if ( err != HB_MC_SUCCESS) {
-                                bsg_pr_err("%s: failed to read A[%d] from DRAM coord (%d,%d) addr %d.\n", __func__, i, dram_coord_x, dram_coord_y, BASE_ADDR + i);
+                                bsg_pr_err("%s: failed to read A[%d] from DRAM coord (%d,%d) addr 0x%08x.\n",
+                                           __func__, i, dram_coord_x, dram_coord_y, dram_epa);
                                 return err;
                         }
 
                         if (A_host != A_device) {
-                                bsg_pr_err(BSG_RED("Mismatch: ") "A_host[%d] = %d   !=   A_device[%d] = %d -- EPA: %d.\n", i, A_host, i, A_device, BASE_ADDR + i);
+                                bsg_pr_err(BSG_RED("Mismatch: ") "A_host[%d] = %d   !=   A_device[%d] = %d -- EPA: 0x%08x.\n",
+                                           i, A_host, i, A_device, dram_epa);
                                 mismatch = 1;
                         }
                 } 

--- a/regression/library/test_vcache_stride.c
+++ b/regression/library/test_vcache_stride.c
@@ -63,9 +63,10 @@ int test_vcache_stride() {
 
         /* To increase the number of DRAM banks tested, increase ndrams (must be
          * less than dim_x) and add the X coordinates to dim_x */
-        int dram = 0, ndrams = 1;
+        int dram = 0, ndrams = dim_x;
         hb_mc_idx_t dram_xs[dim_x];
-        dram_xs[0] = 0;
+        for (hb_mc_idx_t x = 0; x < dim_x; x++) dram_xs[x] = x;
+
         hb_mc_idx_t dram_coord_y = hb_mc_config_get_dram_y(config);
         hb_mc_idx_t dram_coord_x = -1;
         hb_mc_epa_t epa;
@@ -92,7 +93,7 @@ int test_vcache_stride() {
                         npa = hb_mc_epa_to_npa(dest, epa);
                         val = gold[stride];
 
-                        bsg_pr_test_info("%s -- Writing value %lu to 0x%x @ (%d, %d)\n", 
+                        bsg_pr_test_info("%s -- Writing value %08x to 0x%08x @ (%d, %d)\n",
                                         __func__, val, epa, dram_coord_x, dram_coord_y);
                         rc = hb_mc_manycore_write32(&mc, &npa, val);
                         if(rc != HB_MC_SUCCESS) {
@@ -106,14 +107,14 @@ int test_vcache_stride() {
                                 bsg_pr_test_err("%s -- hb_mc_read32 failed on iteration %d!\n", __func__, stride);
                                 return HB_MC_FAIL;
                         }
-                        bsg_pr_test_info("%s -- Read value %lu from 0x%x @ (%d, %d)\n", 
+                        bsg_pr_test_info("%s -- Read value %08x from 0x%08x @ (%d, %d)\n",
                                         __func__, val, epa, dram_coord_x, dram_coord_y);
                         result[stride] = val;
                 }
         }
         for (stride = 0; stride < NUM_STRIDES; ++stride) {
                 if(result[stride] != gold[stride]){
-                        bsg_pr_test_err("%s -- Index %d: Result, %lu, did not match expected, %lu!\n", 
+                        bsg_pr_test_err("%s -- Index %d: Result, %08x, did not match expected, %08x!\n",
                                         __func__, stride, result[stride], gold[stride]);
                         return HB_MC_FAIL;
                 }


### PR DESCRIPTION
* test_vcache_flush uses cache parameters in the ROM instead of hardcoded values
* test_vcache_flush enumerates all column caches instead of just column 0
* test_vcache_sequence increments the addresses by word size instead of by byte