### PR TITLE
Adds snooping the bus to axi_to_mcl for print_stat packets 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.swp
 *.str
 *.log
+*.csv
 *~
 __pycache__
 .Xil

--- a/hardware/bsg_print_stat_snoop.v
+++ b/hardware/bsg_print_stat_snoop.v
@@ -1,0 +1,47 @@
+module bsg_print_stat_snoop
+  import bsg_manycore_pkg::*;
+  import bsg_manycore_addr_pkg::*;
+  #(parameter data_width_p="inv"
+    , parameter addr_width_p="inv"
+    , parameter x_cord_width_p="inv"
+    , parameter y_cord_width_p="inv"
+    , parameter load_id_width_p="inv"
+
+    , parameter link_sif_width_lp=
+      `bsg_manycore_link_sif_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p,load_id_width_p)
+    
+  )
+  (
+    // manycore side
+    input [link_sif_width_lp-1:0] loader_link_sif_in_i
+    , input [link_sif_width_lp-1:0] loader_link_sif_out_i
+
+    // snoop signals
+    , output logic print_stat_v_o
+    , output logic [data_width_p-1:0] print_stat_tag_o
+  );
+
+  `declare_bsg_manycore_link_sif_s(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p,load_id_width_p);
+
+  bsg_manycore_link_sif_s loader_link_sif_in;
+  bsg_manycore_link_sif_s loader_link_sif_out;
+
+  assign loader_link_sif_in = loader_link_sif_in_i;
+  assign loader_link_sif_out = loader_link_sif_out_i;
+
+
+  `declare_bsg_manycore_packet_s(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p,load_id_width_p);
+  bsg_manycore_packet_s fwd_pkt;
+  assign fwd_pkt = loader_link_sif_in.fwd.data;
+
+
+  assign print_stat_v_o = loader_link_sif_in.fwd.v
+    & (fwd_pkt.addr == (bsg_print_stat_epa_gp >> 2)) & loader_link_sif_out.fwd.ready_and_rev;
+  assign print_stat_tag_o = fwd_pkt.payload.data;
+
+  
+
+
+  
+
+endmodule

--- a/hardware/cl_manycore.sv
+++ b/hardware/cl_manycore.sv
@@ -34,6 +34,7 @@
 module cl_manycore
   import cl_manycore_pkg::*;
   import bsg_manycore_pkg::*;
+  import bsg_manycore_addr_pkg::*;
    import bsg_bladerunner_rom_pkg::*;
    import bsg_bladerunner_mem_cfg_pkg::*;
    (
@@ -347,6 +348,15 @@ module cl_manycore
       ,.loader_link_sif_i(loader_link_sif_li)
       ,.loader_link_sif_o(loader_link_sif_lo)
       );
+
+  // print stat signals for vanilla_core_profiler module
+  `declare_bsg_manycore_packet_s(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p,load_id_width_p);
+  bsg_manycore_packet_s fwd_pkt;
+  logic print_stat_v;
+  logic [data_width_p-1:0] print_stat_tag;
+  assign fwd_pkt = loader_link_sif_lo.fwd.data;
+  assign print_stat_v = loader_link_sif_lo.fwd.v & (fwd_pkt.addr == (bsg_print_stat_epa_gp >> 2)) & loader_link_sif_li.fwd.ready_and_rev;
+  assign print_stat_tag = fwd_pkt.payload.data;
 
 `ifdef COSIM
 
@@ -1098,8 +1108,8 @@ module cl_manycore
      (
       .*
       ,.global_ctr_i($root.tb.card.fpga.CL.global_ctr)
-      ,.print_stat_v_i($root.tb.card.fpga.CL.print_stat_v_lo)
-      ,.print_stat_tag_i($root.tb.card.fpga.CL.print_stat_tag_lo)
+      ,.print_stat_v_i($root.tb.card.fpga.CL.print_stat_v)
+      ,.print_stat_tag_i($root.tb.card.fpga.CL.print_stat_tag)
       ,.trace_en_i($root.tb.card.fpga.CL.trace_en)
       );
 

--- a/hardware/cl_manycore.sv
+++ b/hardware/cl_manycore.sv
@@ -349,14 +349,11 @@ module cl_manycore
       ,.loader_link_sif_o(loader_link_sif_lo)
       );
 
+
+
+`ifdef COSIM
+
   // print stat signals for vanilla_core_profiler module
-  /*
-  `declare_bsg_manycore_packet_s(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p,load_id_width_p);
-  bsg_manycore_packet_s fwd_pkt;
-  assign fwd_pkt = loader_link_sif_lo.fwd.data;
-  assign print_stat_v = loader_link_sif_lo.fwd.v & (fwd_pkt.addr == (bsg_print_stat_epa_gp >> 2)) & loader_link_sif_li.fwd.ready_and_rev;
-  assign print_stat_tag = fwd_pkt.payload.data;
-  */
   logic print_stat_v;
   logic [data_width_p-1:0] print_stat_tag;
 
@@ -373,9 +370,6 @@ module cl_manycore
     ,.print_stat_v_o(print_stat_v)
     ,.print_stat_tag_o(print_stat_tag)
   );
-
-
-`ifdef COSIM
 
    bsg_manycore_link_sif_s async_link_sif_li;
    bsg_manycore_link_sif_s async_link_sif_lo;
@@ -513,7 +507,7 @@ module cl_manycore
 
     end
 
-    // synopsys translate off
+    // synopsys translate_off
 
     bind bsg_cache vcache_profiler #(
       .data_width_p(data_width_p)
@@ -524,7 +518,7 @@ module cl_manycore
       ,.print_stat_v_i($root.tb.card.fpga.CL.print_stat_v_lo)
       ,.print_stat_tag_i($root.tb.card.fpga.CL.print_stat_tag_lo)
     );
-    // synopsys translate on
+    // synopsys translate_on
 
   end // block: lv1_vcache
   else if (mem_cfg_p == e_vcache_non_blocking_axi4_f1_dram ||
@@ -564,7 +558,7 @@ module cl_manycore
 
     end
 
-    // synopsys translate off
+    // synopsys translate_off
 
     bind bsg_cache_non_blocking vcache_non_blocking_profiler #(
       .data_width_p(data_width_p)
@@ -599,7 +593,7 @@ module cl_manycore
       ,.print_stat_v_i($root.tb.card.fpga.CL.print_stat_v_lo)
       ,.print_stat_tag_i($root.tb.card.fpga.CL.print_stat_tag_lo)
     );
-    // synopsys translate on
+    // synopsys translate_on
 
   end
   

--- a/hardware/cl_manycore.sv
+++ b/hardware/cl_manycore.sv
@@ -350,13 +350,30 @@ module cl_manycore
       );
 
   // print stat signals for vanilla_core_profiler module
+  /*
   `declare_bsg_manycore_packet_s(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p,load_id_width_p);
   bsg_manycore_packet_s fwd_pkt;
-  logic print_stat_v;
-  logic [data_width_p-1:0] print_stat_tag;
   assign fwd_pkt = loader_link_sif_lo.fwd.data;
   assign print_stat_v = loader_link_sif_lo.fwd.v & (fwd_pkt.addr == (bsg_print_stat_epa_gp >> 2)) & loader_link_sif_li.fwd.ready_and_rev;
   assign print_stat_tag = fwd_pkt.payload.data;
+  */
+  logic print_stat_v;
+  logic [data_width_p-1:0] print_stat_tag;
+
+  bsg_print_stat_snoop #(
+    .data_width_p(data_width_p)
+    ,.addr_width_p(addr_width_p)
+    ,.x_cord_width_p(x_cord_width_p)
+    ,.y_cord_width_p(y_cord_width_p)
+    ,.load_id_width_p(load_id_width_p)
+  ) print_stat_snoop0 (
+    .loader_link_sif_in_i(loader_link_sif_lo)
+    ,.loader_link_sif_out_i(loader_link_sif_li)
+
+    ,.print_stat_v_o(print_stat_v)
+    ,.print_stat_tag_o(print_stat_tag)
+  );
+
 
 `ifdef COSIM
 

--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -95,6 +95,7 @@ VSOURCES += $(HARDWARE_PATH)/bsg_bladerunner_configuration.v
 VSOURCES += $(HARDWARE_PATH)/cl_manycore_pkg.v
 VSOURCES += $(HARDWARE_PATH)/$(CL_TOP_MODULE).sv
 VSOURCES += $(HARDWARE_PATH)/bsg_manycore_wrapper.v
+VSOURCES += $(HARDWARE_PATH)/bsg_print_stat_snoop.v
 
 VSOURCES += $(CL_DIR)/hardware/bsg_bladerunner_rom.v
 VSOURCES += $(CL_DIR)/hardware/axil_to_mcl.v


### PR DESCRIPTION
Credit to @tommydcjung 
- Added snooping from the loader_link_sif_li/lo to intercept packets intended for bsg_print_stat and use it as input for vanilla core profiler.
- This fixes the clock domain crossing issue with the print_stat_v_i signal that is on main_clk_a0, vs. the vanilla_core_profiler which is on core_clock.
- Fixes the missing print_stat signals issue # 205 in bsg_manycore.
Cosim Regression passed.