### PR TITLE
Amoswap

### DIFF
--- a/hardware/bsg_bladerunner_rom.v
+++ b/hardware/bsg_bladerunner_rom.v
@@ -18,7 +18,6 @@ module bsg_bladerunner_rom
   ,addr_width_p="inv"
   ,data_width_p="inv"
   ,max_out_credits_p=16
-  ,load_id_width_p="inv"
   ,data_mask_width_lp=(data_width_p>>3)
   ,link_sif_width_lp=`bsg_manycore_link_sif_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p)
 ) (input clk_i
@@ -49,7 +48,6 @@ module bsg_bladerunner_rom
     ,.addr_width_p     (addr_width_p)
     ,.data_width_p     (data_width_p)
     ,.max_out_credits_p(max_out_credits_p)
-    ,.load_id_width_p  (load_id_width_p)
   ) mcl_endpoint_standard (
     .clk_i
     ,.reset_i

--- a/hardware/bsg_bladerunner_rom.v
+++ b/hardware/bsg_bladerunner_rom.v
@@ -20,7 +20,7 @@ module bsg_bladerunner_rom
   ,max_out_credits_p=16
   ,load_id_width_p="inv"
   ,data_mask_width_lp=(data_width_p>>3)
-  ,link_sif_width_lp=`bsg_manycore_link_sif_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p,load_id_width_p)
+  ,link_sif_width_lp=`bsg_manycore_link_sif_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p)
 ) (input clk_i
   , input reset_i
 

--- a/hardware/bsg_manycore_wrapper.v
+++ b/hardware/bsg_manycore_wrapper.v
@@ -16,7 +16,6 @@ module bsg_manycore_wrapper
     , parameter icache_tag_width_p="inv"
     , parameter epa_byte_addr_width_p="inv"
     , parameter dram_ch_addr_width_p="inv"
-    , parameter load_id_width_p="inv"
     , parameter vcache_size_p="inv"
     , parameter vcache_block_size_in_words_p="inv"
     , parameter vcache_sets_p="inv"
@@ -72,7 +71,6 @@ module bsg_manycore_wrapper
     ,.epa_byte_addr_width_p(epa_byte_addr_width_p)
     ,.dram_ch_addr_width_p(dram_ch_addr_width_p)
     ,.data_width_p(data_width_p)
-    ,.load_id_width_p(load_id_width_p)
     ,.vcache_size_p(vcache_size_p)
     ,.vcache_block_size_in_words_p(vcache_block_size_in_words_p)
     ,.vcache_sets_p(vcache_sets_p)
@@ -125,7 +123,6 @@ module bsg_manycore_wrapper
       ,.data_width_p(data_width_p)
       ,.x_cord_width_p(x_cord_width_lp)
       ,.y_cord_width_p(y_cord_width_lp)
-      ,.load_id_width_p(load_id_width_p)
     ) tieoff_w (
       .clk_i(clk_i)
       ,.reset_i(reset_i)
@@ -140,7 +137,6 @@ module bsg_manycore_wrapper
       ,.data_width_p(data_width_p)
       ,.x_cord_width_p(x_cord_width_lp)
       ,.y_cord_width_p(y_cord_width_lp)
-      ,.load_id_width_p(load_id_width_p)
     ) tieoff_e (
       .clk_i(clk_i)
       ,.reset_i(reset_i)
@@ -155,7 +151,6 @@ module bsg_manycore_wrapper
       ,.data_width_p(data_width_p)
       ,.x_cord_width_p(x_cord_width_lp)
       ,.y_cord_width_p(y_cord_width_lp)
-      ,.load_id_width_p(load_id_width_p)
     ) tieoff_n (
       .clk_i(clk_i)
       ,.reset_i(reset_i)
@@ -170,7 +165,6 @@ module bsg_manycore_wrapper
       ,.data_width_p(data_width_p)
       ,.x_cord_width_p(x_cord_width_lp)
       ,.y_cord_width_p(y_cord_width_lp)
-      ,.load_id_width_p(load_id_width_p)
     ) tieoff_s (
       .clk_i(clk_i)
       ,.reset_i(reset_i)
@@ -185,7 +179,6 @@ module bsg_manycore_wrapper
       ,.data_width_p(data_width_p)
       ,.x_cord_width_p(x_cord_width_lp)
       ,.y_cord_width_p(y_cord_width_lp)
-      ,.load_id_width_p(load_id_width_p)
     ) tieoff_io (
       .clk_i(clk_i)
       ,.reset_i(reset_i)

--- a/hardware/bsg_manycore_wrapper.v
+++ b/hardware/bsg_manycore_wrapper.v
@@ -28,7 +28,7 @@ module bsg_manycore_wrapper
     , parameter y_cord_width_lp=`BSG_SAFE_CLOG2(num_tiles_y_p+2)
   
     , parameter link_sif_width_lp=
-      `bsg_manycore_link_sif_width(addr_width_p,data_width_p,x_cord_width_lp,y_cord_width_lp,load_id_width_p)
+      `bsg_manycore_link_sif_width(addr_width_p,data_width_p,x_cord_width_lp,y_cord_width_lp)
   )
   (
     input clk_i
@@ -46,7 +46,7 @@ module bsg_manycore_wrapper
 
   // manycore
   //
-  `declare_bsg_manycore_link_sif_s(addr_width_p,data_width_p,x_cord_width_lp,y_cord_width_lp,load_id_width_p);
+  `declare_bsg_manycore_link_sif_s(addr_width_p,data_width_p,x_cord_width_lp,y_cord_width_lp);
 
   bsg_manycore_link_sif_s [E:W][num_tiles_y_p:0] hor_link_sif_li;
   bsg_manycore_link_sif_s [E:W][num_tiles_y_p:0] hor_link_sif_lo;

--- a/hardware/cl_manycore.sv
+++ b/hardware/cl_manycore.sv
@@ -303,7 +303,7 @@ module cl_manycore
 `endif
 
 
-   `declare_bsg_manycore_link_sif_s(addr_width_p, data_width_p, x_cord_width_p, y_cord_width_p, load_id_width_p);
+   `declare_bsg_manycore_link_sif_s(addr_width_p, data_width_p, x_cord_width_p, y_cord_width_p);
 
    bsg_manycore_link_sif_s [num_cache_p-1:0] cache_link_sif_li;
    bsg_manycore_link_sif_s [num_cache_p-1:0] cache_link_sif_lo;
@@ -353,27 +353,29 @@ module cl_manycore
    bsg_manycore_link_sif_s async_link_sif_li;
    bsg_manycore_link_sif_s async_link_sif_lo;
 
-   bsg_manycore_link_sif_async_buffer #(
-                                        .addr_width_p(addr_width_p)
-                                        ,.data_width_p(data_width_p)
-                                        ,.x_cord_width_p(x_cord_width_p)
-                                        ,.y_cord_width_p(y_cord_width_p)
-                                        ,.load_id_width_p(load_id_width_p)
-                                        ,.fifo_els_p(16)
-                                        ) async_buf (
+   bsg_manycore_link_sif_async_buffer
+     #(
+       .addr_width_p(addr_width_p)
+       ,.data_width_p(data_width_p)
+       ,.x_cord_width_p(x_cord_width_p)
+       ,.y_cord_width_p(y_cord_width_p)
+       ,.load_id_width_p(load_id_width_p)
+       ,.fifo_els_p(16)
+       )
+  async_buf
+    (
+     // core side
+     .L_clk_i(core_clk)
+     ,.L_reset_i(core_reset)
+     ,.L_link_sif_i(loader_link_sif_lo)
+     ,.L_link_sif_o(loader_link_sif_li)
 
-                                                     // core side
-                                                     .L_clk_i(core_clk)
-                                                     ,.L_reset_i(core_reset)
-                                                     ,.L_link_sif_i(loader_link_sif_lo)
-                                                     ,.L_link_sif_o(loader_link_sif_li)
-
-                                                     // AXI-L side
-                                                     ,.R_clk_i(clk_main_a0)
-                                                     ,.R_reset_i(~rst_main_n_sync)
-                                                     ,.R_link_sif_i(async_link_sif_li)
-                                                     ,.R_link_sif_o(async_link_sif_lo)
-                                                     );
+     // AXI-L side
+     ,.R_clk_i(clk_main_a0)
+     ,.R_reset_i(~rst_main_n_sync)
+     ,.R_link_sif_i(async_link_sif_li)
+     ,.R_link_sif_o(async_link_sif_lo)
+     );
 
 `endif
 

--- a/hardware/cl_manycore.sv
+++ b/hardware/cl_manycore.sv
@@ -326,7 +326,6 @@ module cl_manycore
        ,.icache_tag_width_p(icache_tag_width_p)
        ,.epa_byte_addr_width_p(epa_byte_addr_width_p)
        ,.dram_ch_addr_width_p(dram_ch_addr_width_p)
-       ,.load_id_width_p(load_id_width_p)
        ,.num_cache_p(num_cache_p)
        ,.vcache_size_p(vcache_size_p)
        ,.vcache_block_size_in_words_p(block_size_in_words_p)
@@ -359,7 +358,6 @@ module cl_manycore
        ,.data_width_p(data_width_p)
        ,.x_cord_width_p(x_cord_width_p)
        ,.y_cord_width_p(y_cord_width_p)
-       ,.load_id_width_p(load_id_width_p)
        ,.fifo_els_p(16)
        )
   async_buf
@@ -429,7 +427,6 @@ module cl_manycore
         ,.addr_width_p(addr_width_p)
         ,.x_cord_width_p(x_cord_width_p)
         ,.y_cord_width_p(y_cord_width_p)
-        ,.load_id_width_p(load_id_width_p)
       ) mem_infty (
         .clk_i(core_clk)
         ,.reset_i(core_reset)
@@ -1079,7 +1076,6 @@ module cl_manycore
        ,.data_width_p     (data_width_p     )
        ,.x_cord_width_p   (x_cord_width_p   )
        ,.y_cord_width_p   (y_cord_width_p   )
-       ,.load_id_width_p  (load_id_width_p  )
        ,.max_out_credits_p(max_out_credits_p)
        ) 
    axil_to_mcl_inst 

--- a/hardware/cl_manycore.sv
+++ b/hardware/cl_manycore.sv
@@ -521,7 +521,6 @@ module cl_manycore
         ,.miss_fifo_els_p(miss_fifo_els_p)
         ,.x_cord_width_p(x_cord_width_p)
         ,.y_cord_width_p(y_cord_width_p)
-        ,.load_id_width_p(load_id_width_p)
       ) vcache_nb (
         .clk_i(core_clk)
         ,.reset_i(core_reset)

--- a/hardware/cl_manycore.sv
+++ b/hardware/cl_manycore.sv
@@ -467,7 +467,6 @@ module cl_manycore
 
         ,.x_cord_width_p(x_cord_width_p)
         ,.y_cord_width_p(y_cord_width_p)
-        ,.load_id_width_p(load_id_width_p)
       ) vcache (
         .clk_i(core_clk)
         ,.reset_i(core_reset)

--- a/hardware/cl_manycore.sv
+++ b/hardware/cl_manycore.sv
@@ -473,9 +473,6 @@ module cl_manycore
         // memory systems link from bsg_manycore_wrapper
         ,.link_sif_i(cache_link_sif_lo[i])
         ,.link_sif_o(cache_link_sif_li[i])
-        // coordinates for memory system are determined by bsg_manycore_wrapper
-        ,.my_x_i(cache_x_lo[i])
-        ,.my_y_i(cache_y_lo[i])
 
         ,.dma_pkt_o(lv1_dma.dma_pkt[i])
         ,.dma_pkt_v_o(lv1_dma.dma_pkt_v_lo[i])

--- a/hardware/cl_manycore_pkg.v
+++ b/hardware/cl_manycore_pkg.v
@@ -19,7 +19,6 @@ package cl_manycore_pkg;
   parameter num_tiles_y_p = `CL_MANYCORE_DIM_Y;
   parameter x_cord_width_p = `BSG_SAFE_CLOG2(num_tiles_x_p);
   parameter y_cord_width_p = `BSG_SAFE_CLOG2(num_tiles_y_p+2);
-  parameter load_id_width_p = 12;
   parameter dmem_size_p = 1024;
   parameter icache_entries_p = 1024;
   parameter icache_tag_width_p = 12;

--- a/machines/4x4_amo_support
+++ b/machines/4x4_amo_support
@@ -1,0 +1,1 @@
+4x4_blocking_vcache_f1_model/

--- a/machines/4x4_blocking_vcache_f1_model/Makefile.machine.include
+++ b/machines/4x4_blocking_vcache_f1_model/Makefile.machine.include
@@ -1,0 +1,52 @@
+# Copyright (c) 2019, University of Washington All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+# 
+# Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+# 
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+# 
+# Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+BSG_MACHINE_GLOBAL_X                  = 4
+BSG_MACHINE_GLOBAL_Y                  = 5
+BSG_MACHINE_VCACHE_SET                = 64
+BSG_MACHINE_VCACHE_WAY                = 8
+BSG_MACHINE_VCACHE_BLOCK_SIZE_WORDS   = 16
+BSG_MACHINE_VCACHE_STRIPE_SIZE_WORDS  = $(BSG_MACHINE_VCACHE_BLOCK_SIZE_WORDS)
+BSG_MACHINE_VCACHE_MISS_FIFO_ELS      = 32
+BSG_MACHINE_DRAM_INCLUDED             = 1
+BSG_MACHINE_MAX_EPA_WIDTH             = 28
+BSG_MACHINE_DRAM_SIZE_WORDS           = 536870912
+BSG_MACHINE_DRAM_BANK_SIZE_WORDS      = 134217728
+
+BSG_MACHINE_DATA_WIDTH                = 32
+
+# This flag has to be always 0 by default. Conditional
+# assignment allows user to set this flag through
+# environment when required.
+BSG_MACHINE_BRANCH_TRACE_EN          ?= 0 
+
+CL_MANYCORE_HOST_COORD_X             := 0
+CL_MANYCORE_HOST_COORD_Y             := 0
+CL_MANYCORE_DIM_X                    := $(BSG_MACHINE_GLOBAL_X)
+CL_MANYCORE_DIM_Y                    := $(shell expr $(BSG_MACHINE_GLOBAL_Y) - 1)
+
+CL_MANYCORE_MEM_CFG                  := e_vcache_blocking_axi4_f1_model

--- a/regression/cuda/tests.mk
+++ b/regression/cuda/tests.mk
@@ -40,6 +40,8 @@ UNIFIED_TESTS = test_scalar_print
 UNIFIED_TESTS += test_empty
 UNIFIED_TESTS += test_tile_info
 UNIFIED_TESTS += test_barrier
+UNIFIED_TESTS += test_vcache_atomic_histogram
+UNIFIED_TESTS += test_vcache_atomic_inc
 
 # "Independent Tests" use a per-test <test_name>.c file
 INDEPENDENT_TESTS += test_binary_load_buffer

--- a/regression/spmd/test_loader.c
+++ b/regression/spmd/test_loader.c
@@ -142,7 +142,6 @@ int test_loader(int argc, char **argv) {
 
         while (1) {
                 hb_mc_packet_t pkt;
-                int err;
                 bsg_pr_dbg("Waiting for finish packet\n");
                 
                 err = hb_mc_manycore_packet_rx(mc, &pkt, HB_MC_FIFO_RX_REQ, -1);

--- a/regression/spmd/tests.mk
+++ b/regression/spmd/tests.mk
@@ -36,6 +36,7 @@ SRC_PATH=$(REGRESSION_PATH)/$(REGRESSION_TESTS_TYPE)/
 UNIFIED_TESTS = test_fib 
 UNIFIED_TESTS += test_bsg_print_stat
 UNIFIED_TESTS += test_putchar_stream
+UNIFIED_TESTS += test_vcache_atomics
 
 # "Independent Tests" use a per-test <test_name>.c file
 INDEPENDENT_TESTS := test_bsg_dram_loopback_cache


### PR DESCRIPTION
* depends on https://github.com/bespoke-silicon-group/bsg_manycore/pull/209
* depends on https://github.com/bespoke-silicon-group/basejump_stl/pull/196
* updates mcl <-> axil interface to work with refactored Manycore network packets
* fixes a "false-positive" bug in the spmd test_loader
* adds an optional return code pointer in the cuda test_loader (needed for atomic tests)
* adds a machine config that supports AMO