### PR TITLE
Small fixes and additions to test loader programs

### DIFF
--- a/regression/spmd/test_loader.c
+++ b/regression/spmd/test_loader.c
@@ -142,7 +142,6 @@ int test_loader(int argc, char **argv) {
 
         while (1) {
                 hb_mc_packet_t pkt;
-                int err;
                 bsg_pr_dbg("Waiting for finish packet\n");
                 
                 err = hb_mc_manycore_packet_rx(mc, &pkt, HB_MC_FIFO_RX_REQ, -1);


### PR DESCRIPTION
* adds a return code to the CUDA test_loader that can be ignored but can be set to non-zero to indicate an application failure.
* fixes a bug in which `ret` is shadowed and results in success being returned even on failure.