### PR TITLE
Fixes the alignment check issue for Host API

### DIFF
--- a/libraries/bsg_manycore.cpp
+++ b/libraries/bsg_manycore.cpp
@@ -615,7 +615,7 @@ static int  hb_mc_manycore_mmio_read_mmio(hb_mc_manycore_t *mc, uintptr_t offset
                 manycore_pr_err(mc, "%s: Failed: 0x%" PRIxPTR " "
                                 "is not aligned to 4 byte boundary\n",
                                 __func__, offset);
-                return HB_MC_INVALID;
+                return HB_MC_UNALIGNED;
         }
 
         addr = &addr[offset];
@@ -720,7 +720,7 @@ static int hb_mc_manycore_mmio_write_mmio(hb_mc_manycore_t *mc, uintptr_t offset
                 manycore_pr_err(mc, "%s: Failed: 0x%" PRIxPTR " "
                                 "is not aligned to 4 byte boundary\n",
                                 __func__, offset);
-                return HB_MC_INVALID;
+                return HB_MC_UNALIGNED;
         }
 
         addr = &addr[offset];
@@ -1255,6 +1255,32 @@ static int hb_mc_manycore_format_load_request_packet(hb_mc_manycore_t *mc,
 // Memory API //
 ////////////////
 
+/**
+ * Checks alignment of an epa based on data size in bytes.
+ * @param[in] epa  epa address
+ * @param[in] sz   data size in bytes.
+ * @return         HB_MC_SUCCESS if npa is aligned and HB_MC_UNALIGNED if not,
+ *                 and HB_MC_INVALID otherwise.
+ */
+static inline int hb_mc_manycore_epa_check_alignment(const hb_mc_epa_t *epa, size_t sz)
+{
+        switch (sz) {
+        case 4:
+                if (*epa & 0x3)
+                        return HB_MC_UNALIGNED;
+                break;
+        case 2:
+                if (*epa & 0x1)
+                        return HB_MC_UNALIGNED;
+                break;
+        case 1:
+                break;
+        default:
+                return HB_MC_INVALID;
+        }
+        return HB_MC_SUCCESS;
+}
+
 /* send a read request and don't wait for the return packet */
 static int hb_mc_manycore_send_read_rqst(hb_mc_manycore_t *mc,
                                          const hb_mc_npa_t *npa, size_t sz,
@@ -1271,6 +1297,13 @@ static int hb_mc_manycore_send_read_rqst(hb_mc_manycore_t *mc,
                 return err;
         }
 
+        hb_mc_epa_t epa = hb_mc_npa_get_epa(npa);
+
+        // Check for 4-byte, 2-byte or 1-byte alignment based on size
+        err = hb_mc_manycore_epa_check_alignment(&epa, sz);
+        if (err != HB_MC_SUCCESS)
+                return err;
+
         // mark request with id
         hb_mc_request_packet_set_data(&rqst.request, id);
         int shift = hb_mc_npa_get_epa(npa) & 0x3;
@@ -1280,13 +1313,11 @@ static int hb_mc_manycore_send_read_rqst(hb_mc_manycore_t *mc,
                 hb_mc_request_packet_set_mask(&rqst.request, HB_MC_PACKET_REQUEST_MASK_WORD);
                 break;
         case 2:
-                assert(shift == 0 || shift == 2);
                 hb_mc_request_packet_set_mask(&rqst.request,
                                               static_cast<hb_mc_packet_mask_t>(
                                                       HB_MC_PACKET_REQUEST_MASK_SHORT << shift));
                 break;
         case 1:
-                assert(shift == 0 || shift == 1 || shift == 2 || shift == 3);
                 hb_mc_request_packet_set_mask(&rqst.request, static_cast<hb_mc_packet_mask_t>(
                                                       HB_MC_PACKET_REQUEST_MASK_BYTE << shift));
                 break;
@@ -1379,8 +1410,9 @@ static int hb_mc_manycore_write(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa, co
         hb_mc_epa_t epa = hb_mc_npa_get_epa(npa);
 
         // Check for 4-byte, 2-byte or 1-byte alignment based on size
-        if (hb_mc_epa_check_alignment(&epa, sz) != HB_MC_SUCCESS)
-                return HB_MC_INVALID;
+        err = hb_mc_manycore_epa_check_alignment(&epa, sz);
+        if (err != HB_MC_SUCCESS)
+                return err;
 
         int shift = epa & 0x3;
         /* set data and size */
@@ -1737,8 +1769,6 @@ int hb_mc_manycore_read8(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa, uint8_t *
  */
 int hb_mc_manycore_read16(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa, uint16_t *vp)
 {
-        if(hb_mc_npa_get_epa(npa) & 0x1) // Check for 2-byte alignment by checking lowest bit
-                return HB_MC_INVALID;
         return hb_mc_manycore_read(mc, npa, vp, 2);
 }
 
@@ -1751,8 +1781,6 @@ int hb_mc_manycore_read16(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa, uint16_t
  */
 int hb_mc_manycore_read32(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa, uint32_t *vp)
 {
-        if(hb_mc_npa_get_epa(npa) & 0x3) // Check for 4-byte alignment by checking two lowest bits
-                return HB_MC_INVALID;
         return hb_mc_manycore_read(mc, npa, vp, 4);
 }
 

--- a/libraries/bsg_manycore_epa.h
+++ b/libraries/bsg_manycore_epa.h
@@ -28,11 +28,14 @@
 #ifndef BSG_MANYCORE_EPA_H
 #define BSG_MANYCORE_EPA_H
 #include <bsg_manycore_features.h>
+#include <bsg_manycore_errno.h>
 
 #ifdef __cplusplus
 #include <cstdint>
+#include <cstddef>
 #else
 #include <stdint.h>
+#include <stddef.h>
 #endif
 
 #ifdef __cplusplus
@@ -50,6 +53,33 @@ extern "C" {
 
 #define EPA_FROM_BASE_AND_OFFSET(base, offset)  \
         (((base)+(offset)))
+
+        /**
+         * Checks alignment of an epa based on data size in bytes.
+         * @param[in] epa  epa address
+         * @param[in] sz   data size in bytes.
+         * @return         HB_MC_SUCCESS if npa is aligned and HB_MC_INVALID otherwise.
+         */
+        static inline int hb_mc_epa_check_alignment(const hb_mc_epa_t *epa, size_t sz)
+        {
+                switch (sz) {
+                case 4:
+                        if (*epa & 0x3)
+                                return HB_MC_INVALID;
+                        break;
+                case 2:
+                        if (*epa & 0x1)
+                                return HB_MC_INVALID;
+                        break;
+                case 1:
+                        break;
+                default:
+                        return HB_MC_INVALID;
+                }
+                return HB_MC_SUCCESS;
+        }
+
+
 
 #ifdef __cplusplus
 };

--- a/libraries/bsg_manycore_epa.h
+++ b/libraries/bsg_manycore_epa.h
@@ -28,14 +28,11 @@
 #ifndef BSG_MANYCORE_EPA_H
 #define BSG_MANYCORE_EPA_H
 #include <bsg_manycore_features.h>
-#include <bsg_manycore_errno.h>
 
 #ifdef __cplusplus
 #include <cstdint>
-#include <cstddef>
 #else
 #include <stdint.h>
-#include <stddef.h>
 #endif
 
 #ifdef __cplusplus
@@ -53,33 +50,6 @@ extern "C" {
 
 #define EPA_FROM_BASE_AND_OFFSET(base, offset)  \
         (((base)+(offset)))
-
-        /**
-         * Checks alignment of an epa based on data size in bytes.
-         * @param[in] epa  epa address
-         * @param[in] sz   data size in bytes.
-         * @return         HB_MC_SUCCESS if npa is aligned and HB_MC_INVALID otherwise.
-         */
-        static inline int hb_mc_epa_check_alignment(const hb_mc_epa_t *epa, size_t sz)
-        {
-                switch (sz) {
-                case 4:
-                        if (*epa & 0x3)
-                                return HB_MC_INVALID;
-                        break;
-                case 2:
-                        if (*epa & 0x1)
-                                return HB_MC_INVALID;
-                        break;
-                case 1:
-                        break;
-                default:
-                        return HB_MC_INVALID;
-                }
-                return HB_MC_SUCCESS;
-        }
-
-
 
 #ifdef __cplusplus
 };

--- a/libraries/bsg_manycore_errno.h
+++ b/libraries/bsg_manycore_errno.h
@@ -43,6 +43,7 @@ extern "C" {
 #define HB_MC_NOIMPL        (-6)
 #define HB_MC_NOTFOUND      (-7)
 #define HB_MC_BUSY          (-8)
+#define HB_MC_UNALIGNED     (-9)
 
         static inline const char * hb_mc_strerror(int err)
         {
@@ -56,6 +57,7 @@ extern "C" {
                         [-HB_MC_NOIMPL]            = "Not implemented",
                         [-HB_MC_NOTFOUND]          = "Not found",
                         [-HB_MC_BUSY]              = "Busy",
+                        [-HB_MC_UNALIGNED]         = "Unaligned memory request",
                 };
                 return strtab[-err];
         }

--- a/regression/library/test_manycore_alignment.c
+++ b/regression/library/test_manycore_alignment.c
@@ -83,7 +83,7 @@ int test_manycore_alignment() {
                         bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
                 } else {
                         bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
-                                   __func__, npa);
+                                   __func__, hb_mc_npa_get_epa(&npa));
                         return HB_MC_FAIL;
                 }
 
@@ -124,7 +124,7 @@ int test_manycore_alignment() {
                         bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
                 } else {
                         bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
-                                   __func__, npa);
+                                   __func__, hb_mc_npa_get_epa(&npa));
                         return HB_MC_FAIL;
                 }
 
@@ -163,7 +163,7 @@ int test_manycore_alignment() {
                         bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
                 } else {
                         bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
-                                   __func__, npa);
+                                   __func__, hb_mc_npa_get_epa(&npa));
                         return HB_MC_FAIL;
                 }
 
@@ -204,7 +204,7 @@ int test_manycore_alignment() {
                         bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
                 } else {
                         bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
-                                   __func__, npa);
+                                   __func__, hb_mc_npa_get_epa(&npa));
                         return HB_MC_FAIL;
                 }
 
@@ -243,7 +243,7 @@ int test_manycore_alignment() {
                         bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
                 } else {
                         bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
-                                   __func__, npa);
+                                   __func__, hb_mc_npa_get_epa(&npa));
                         return HB_MC_FAIL;
                 }
 
@@ -271,7 +271,7 @@ int test_manycore_alignment() {
                         bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
                 } else {
                         bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
-                                   __func__, npa);
+                                   __func__, hb_mc_npa_get_epa(&npa));
                         return HB_MC_FAIL;
                 }
 

--- a/regression/library/test_manycore_alignment.c
+++ b/regression/library/test_manycore_alignment.c
@@ -1,0 +1,327 @@
+// Copyright (c) 2019, University of Washington All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+// 
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+// 
+// Neither the name of the copyright holder nor the names of its contributors may
+// be used to endorse or promote products derived from this software without
+// specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <inttypes.h>
+#include <bsg_manycore.h>
+#include <bsg_manycore_config.h>
+#include <bsg_manycore_coordinate.h>
+#include <bsg_manycore_printing.h>
+#include <bsg_manycore_npa.h>
+#include "test_manycore_alignment.h"
+
+#define TEST_NAME "test_manycore_alignment"
+
+#define BASE_ADDR 0x0000
+
+int test_manycore_alignment() {
+        /********/
+        /* INIT */
+        /********/
+        int err, r = HB_MC_FAIL;
+        hb_mc_manycore_t manycore = {0}, *mc = &manycore;
+
+        srand(time(0));
+        
+        err = hb_mc_manycore_init(mc, TEST_NAME, 0);
+        if (err != HB_MC_SUCCESS) {
+                bsg_pr_err("%s: failed to intialize manycore: %s\n",
+                           __func__,
+                           hb_mc_strerror(err));
+                return HB_MC_FAIL;
+        }
+
+        const hb_mc_config_t *config = hb_mc_manycore_get_config(mc);
+        uint32_t manycore_dim_x = hb_mc_coordinate_get_x(hb_mc_config_get_dimension_vcore(config));
+
+        hb_mc_dimension_t dim = hb_mc_config_get_dimension_network(config);
+
+        uint32_t dram_coord_x = 0;
+
+        uint32_t dram_coord_y = hb_mc_config_get_dram_y(config);
+        int mismatch = 0;
+
+        /*
+         * Loop over all DRAM banks and try to read/write to an unaligned address
+         */
+        for (dram_coord_x = 0; dram_coord_x < hb_mc_dimension_get_x(dim); dram_coord_x++) {
+                uint32_t write_data, read_data;
+                bsg_pr_test_info("%s: Testing DRAM bank (%" PRIu32 ",%" PRIu32 ")\n",
+                                 __func__, dram_coord_x, dram_coord_y);
+
+                // Write a 4-byte word into mis-aligned addresses to
+                // verify that API returns an invalid address error
+                hb_mc_npa_t npa = hb_mc_npa_from_x_y(dram_coord_x,
+                                                     dram_coord_y,
+                                                     BASE_ADDR + 1);
+                write_data = rand();
+                err = hb_mc_manycore_write_mem(mc, &npa, &write_data, sizeof(write_data));
+                if (err == HB_MC_UNALIGNED) { 
+                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
+                } else {
+                        bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
+                                   __func__, npa);
+                        return HB_MC_FAIL;
+                }
+
+                npa = hb_mc_npa_from_x_y(dram_coord_x,
+                                         dram_coord_y,
+                                         BASE_ADDR + 2);
+                write_data = rand();
+                err = hb_mc_manycore_write_mem(mc, &npa, &write_data, sizeof(write_data));
+                if (err == HB_MC_UNALIGNED) {
+                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
+                } else {
+                        bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
+                                   __func__, hb_mc_npa_get_epa(&npa));
+                        return HB_MC_FAIL;
+                }
+
+                npa = hb_mc_npa_from_x_y(dram_coord_x,
+                                         dram_coord_y,
+                                         BASE_ADDR + 3);
+                write_data = rand();
+                err = hb_mc_manycore_write_mem(mc, &npa, &write_data, sizeof(write_data));
+                if (err == HB_MC_UNALIGNED) {
+                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
+                } else {
+                        bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
+                                   __func__, hb_mc_npa_get_epa(&npa));
+                        return HB_MC_FAIL;
+                }
+
+
+                // Read a 4-byte word from mis-aligned addresses to 
+                // verify that API returns an invalid address error
+                npa = hb_mc_npa_from_x_y(dram_coord_x,
+                                         dram_coord_y,
+                                         BASE_ADDR + 1);
+                err = hb_mc_manycore_read_mem(mc, &npa, &read_data, sizeof(read_data));
+                if (err == HB_MC_UNALIGNED) { 
+                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
+                } else {
+                        bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
+                                   __func__, npa);
+                        return HB_MC_FAIL;
+                }
+
+                npa = hb_mc_npa_from_x_y(dram_coord_x,
+                                         dram_coord_y,
+                                         BASE_ADDR + 2);
+                err = hb_mc_manycore_read_mem(mc, &npa, &read_data, sizeof(read_data));
+                if (err == HB_MC_UNALIGNED) {
+                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
+                } else {
+                        bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
+                                   __func__, hb_mc_npa_get_epa(&npa));
+                        return HB_MC_FAIL;
+                }
+
+                npa = hb_mc_npa_from_x_y(dram_coord_x,
+                                         dram_coord_y,
+                                         BASE_ADDR + 3);
+                err = hb_mc_manycore_read_mem(mc, &npa, &read_data, sizeof(read_data));
+                if (err == HB_MC_UNALIGNED) {
+                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
+                } else {
+                        bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
+                                   __func__, hb_mc_npa_get_epa(&npa));
+                        return HB_MC_FAIL;
+                }
+
+                // Write a 4-byte word into mis-aligned addresses to
+                // verify that API returns an invalid address error
+                npa = hb_mc_npa_from_x_y(dram_coord_x,
+                                         dram_coord_y,
+                                         BASE_ADDR + 1);
+                write_data = rand();
+                err = hb_mc_manycore_write32(mc, &npa, &write_data);
+                if (err == HB_MC_UNALIGNED) { 
+                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
+                } else {
+                        bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
+                                   __func__, npa);
+                        return HB_MC_FAIL;
+                }
+
+                npa = hb_mc_npa_from_x_y(dram_coord_x,
+                                         dram_coord_y,
+                                         BASE_ADDR + 2);
+                write_data = rand();
+                err = hb_mc_manycore_write32(mc, &npa, &write_data);
+                if (err == HB_MC_UNALIGNED) {
+                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
+                } else {
+                        bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
+                                   __func__, hb_mc_npa_get_epa(&npa));
+                        return HB_MC_FAIL;
+                }
+
+                npa = hb_mc_npa_from_x_y(dram_coord_x,
+                                         dram_coord_y,
+                                         BASE_ADDR + 3);
+                write_data = rand();
+                err = hb_mc_manycore_write32(mc, &npa, &write_data);
+                if (err == HB_MC_UNALIGNED) {
+                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
+                } else {
+                        bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
+                                   __func__, hb_mc_npa_get_epa(&npa));
+                        return HB_MC_FAIL;
+                }
+
+
+                // Read a 4-byte word from mis-aligned addresses to 
+                // verify that API returns an invalid address error
+                npa = hb_mc_npa_from_x_y(dram_coord_x,
+                                         dram_coord_y,
+                                         BASE_ADDR + 1);
+                err = hb_mc_manycore_read32(mc, &npa, &read_data);
+                if (err == HB_MC_UNALIGNED) { 
+                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
+                } else {
+                        bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
+                                   __func__, npa);
+                        return HB_MC_FAIL;
+                }
+
+                npa = hb_mc_npa_from_x_y(dram_coord_x,
+                                         dram_coord_y,
+                                         BASE_ADDR + 2);
+                err = hb_mc_manycore_read32(mc, &npa, &read_data);
+                if (err == HB_MC_UNALIGNED) {
+                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
+                } else {
+                        bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
+                                   __func__, hb_mc_npa_get_epa(&npa));
+                        return HB_MC_FAIL;
+                }
+
+                npa = hb_mc_npa_from_x_y(dram_coord_x,
+                                         dram_coord_y,
+                                         BASE_ADDR + 3);
+                err = hb_mc_manycore_read32(mc, &npa, &read_data);
+                if (err == HB_MC_UNALIGNED) {
+                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
+                } else {
+                        bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
+                                   __func__, hb_mc_npa_get_epa(&npa));
+                        return HB_MC_FAIL;
+                }
+
+                // Write a 2-byte value into mis-aligned addresses to
+                // verify that API returns an invalid address error
+                npa = hb_mc_npa_from_x_y(dram_coord_x,
+                                         dram_coord_y,
+                                         BASE_ADDR + 1);
+                write_data = rand();
+                err = hb_mc_manycore_write16(mc, &npa, &write_data);
+                if (err == HB_MC_UNALIGNED) { 
+                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
+                } else {
+                        bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
+                                   __func__, npa);
+                        return HB_MC_FAIL;
+                }
+
+                npa = hb_mc_npa_from_x_y(dram_coord_x,
+                                         dram_coord_y,
+                                         BASE_ADDR + 3);
+                write_data = rand();
+                err = hb_mc_manycore_write16(mc, &npa, &write_data);
+                if (err == HB_MC_UNALIGNED) {
+                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
+                } else {
+                        bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
+                                   __func__, hb_mc_npa_get_epa(&npa));
+                        return HB_MC_FAIL;
+                }
+
+
+                // Read a 2-byte value from mis-aligned addresses to 
+                // verify that API returns an invalid address error
+                npa = hb_mc_npa_from_x_y(dram_coord_x,
+                                         dram_coord_y,
+                                         BASE_ADDR + 1);
+                err = hb_mc_manycore_read16(mc, &npa, &read_data);
+                if (err == HB_MC_UNALIGNED) { 
+                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
+                } else {
+                        bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
+                                   __func__, npa);
+                        return HB_MC_FAIL;
+                }
+
+                npa = hb_mc_npa_from_x_y(dram_coord_x,
+                                         dram_coord_y,
+                                         BASE_ADDR + 3);
+                err = hb_mc_manycore_read16(mc, &npa, &read_data);
+                if (err == HB_MC_UNALIGNED) {
+                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
+                } else {
+                        bsg_pr_err("%s: Did not catch write into invalid misaligned address: 0x%08" PRIx32 ".\n",
+                                   __func__, hb_mc_npa_get_epa(&npa));
+                        return HB_MC_FAIL;
+                }
+
+        }
+
+        r = HB_MC_SUCCESS;
+        
+cleanup:        
+        hb_mc_manycore_exit(mc);
+        return r;
+}
+
+#ifdef COSIM
+void cosim_main(uint32_t *exit_code, char * args) {
+        // We aren't passed command line arguments directly so we parse them
+        // from *args. args is a string from VCS - to pass a string of arguments
+        // to args, pass c_args to VCS as follows: +c_args="<space separated
+        // list of args>"
+        int argc = get_argc(args);
+        char *argv[argc];
+        get_argv(args, argc, argv);
+
+#ifdef VCS
+        svScope scope;
+        scope = svGetScopeFromName("tb");
+        svSetScope(scope);
+#endif
+        bsg_pr_test_info(TEST_NAME " Regression Test (COSIMULATION)\n");
+        int rc = test_manycore_alignment();
+        *exit_code = rc;
+        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
+        return;
+}
+#else
+int main(int argc, char ** argv) {
+        bsg_pr_test_info(TEST_NAME " Regression Test (F1)\n");
+        int rc = test_manycore_alignment();
+        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
+        return rc;
+}
+#endif

--- a/regression/library/test_manycore_alignment.h
+++ b/regression/library/test_manycore_alignment.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2019, University of Washington All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+// 
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+// 
+// Neither the name of the copyright holder nor the names of its contributors may
+// be used to endorse or promote products derived from this software without
+// specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <stdio.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <string.h>
+#include <time.h>
+#include <stdlib.h>
+#include "../cl_manycore_regression.h"
+
+

--- a/regression/library/test_manycore_vcache_sequence.c
+++ b/regression/library/test_manycore_vcache_sequence.c
@@ -115,54 +115,6 @@ int test_manycore_vcache_sequence() {
                 }
 
 
-                // Write a 4-byte word into mis-aligned addresses to 
-                // verify that API returns an invalid address error
-                hb_mc_npa_t npa = hb_mc_npa_from_x_y(dram_coord_x,
-                                                     dram_coord_y,
-                                                     BASE_ADDR+ 1);
-                write_data = rand();
-                err = hb_mc_manycore_write_mem(mc, &npa, &write_data, sizeof(write_data));
-                if (err != HB_MC_SUCCESS) { 
-                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
-                        bsg_pr_err("%s: Did not catch write into invalid mis-alined address: 0x%08" PRIx32 ".\n",
-                                   __func__, hb_mc_npa_get_epa(&npa));
-
-                }
-                else {
-                        bsg_pr_err("%s: Did not catch write into invalid mis-alined address: 0x%08" PRIx32 ".\n",
-                                   __func__, hb_mc_npa_get_epa(&npa));
-                        return HB_MC_FAIL;
-                }
-
-                npa = hb_mc_npa_from_x_y(dram_coord_x,
-                                         dram_coord_y,
-                                         BASE_ADDR+ 2);
-                write_data = rand();
-                err = hb_mc_manycore_write_mem(mc, &npa, &write_data, sizeof(write_data));
-                if (err != HB_MC_SUCCESS) {
-                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
-                } 
-                else {
-                        bsg_pr_err("%s: Did not catch write into invalid mis-alined address: 0x%08" PRIx32 ".\n",
-                                   __func__, hb_mc_npa_get_epa(&npa));
-                        return HB_MC_FAIL;
-                }
-
-                npa = hb_mc_npa_from_x_y(dram_coord_x,
-                                         dram_coord_y,
-                                         BASE_ADDR+ 3);
-                write_data = rand();
-                err = hb_mc_manycore_write_mem(mc, &npa, &write_data, sizeof(write_data));
-                if (err != HB_MC_SUCCESS) {
-                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
-                }
-                else {
-                        bsg_pr_err("%s: Did not catch write into invalid mis-alined address: 0x%08" PRIx32 ".\n",
-                                   __func__, hb_mc_npa_get_epa(&npa));
-                        return HB_MC_FAIL;
-                }
-
-
         }
 
         /********************************/

--- a/regression/library/test_manycore_vcache_sequence.c
+++ b/regression/library/test_manycore_vcache_sequence.c
@@ -130,7 +130,7 @@ int test_manycore_vcache_sequence() {
                 }
                 else {
                         bsg_pr_err("%s: Did not catch write into invalid mis-alined address: 0x%08" PRIx32 ".\n",
-                                   __func__, npa);
+                                   __func__, hb_mc_npa_get_epa(&npa));
                         return HB_MC_FAIL;
                 }
 

--- a/regression/library/test_manycore_vcache_sequence.c
+++ b/regression/library/test_manycore_vcache_sequence.c
@@ -66,18 +66,19 @@ int test_manycore_vcache_sequence() {
         /* Loop over all DRAM banks and write ARRAY_LEN words to each */
         /**************************************************************/
         for (dram_coord_x = 0; dram_coord_x < 1; dram_coord_x++) {
-                uint32_t write_data, read_data;
+                uint32_t write_data, read_data, byteaddr;
                 bsg_pr_test_info("%s: Testing DRAM bank (%" PRIu32 ",%" PRIu32 ")\n",
                                  __func__, dram_coord_x, dram_coord_y);
                 
                 for (size_t i = 0; i < ARRAY_LEN; i += 1) {
+                        byteaddr = i << 2;
                         if ((i % 64) == 1)
                                 bsg_pr_test_info("%s: Have written and read back %4zu words\n",
                                                  __func__, i);
                         
                         hb_mc_npa_t npa = hb_mc_npa_from_x_y(dram_coord_x,
                                                              dram_coord_y,
-                                                             BASE_ADDR+(i << 2));
+                                                             BASE_ADDR + byteaddr);
                         write_data = rand();
                         err = hb_mc_manycore_write_mem(mc, &npa, &write_data, sizeof(write_data));
                         if (err != HB_MC_SUCCESS) {
@@ -85,7 +86,7 @@ int test_manycore_vcache_sequence() {
                                            " to DRAM coord (%d,%d) @ 0x08%" PRIx32 ": %s\n",
                                            __func__, i, write_data,
                                            dram_coord_x, dram_coord_y,
-                                           (npa.epa+ (i << 2)) << 2,
+                                           npa.epa + byteaddr,
                                            hb_mc_strerror(err));
                                 goto cleanup;
                         }
@@ -96,7 +97,7 @@ int test_manycore_vcache_sequence() {
                                            "from DRAM coord (%d,%d) @ 0x%08" PRIx32 ": %s\n",
                                            __func__, i,
                                            dram_coord_x, dram_coord_y,
-                                           (npa.epa+ (i << 2)) << 2,
+                                           npa.epa + byteaddr,
                                            hb_mc_strerror(err));
                                 goto cleanup;
                         }

--- a/regression/library/test_manycore_vcache_sequence.c
+++ b/regression/library/test_manycore_vcache_sequence.c
@@ -35,7 +35,7 @@
 
 #define TEST_NAME "test_manycore_vcache_sequence"
 
-#define ARRAY_LEN  4096
+#define ARRAY_LEN 4096
 #define BASE_ADDR 0x0000
 
 int test_manycore_vcache_sequence() {
@@ -70,14 +70,14 @@ int test_manycore_vcache_sequence() {
                 bsg_pr_test_info("%s: Testing DRAM bank (%" PRIu32 ",%" PRIu32 ")\n",
                                  __func__, dram_coord_x, dram_coord_y);
                 
-                for (size_t i = 0; i < ARRAY_LEN; i++) {
+                for (size_t i = 0; i < ARRAY_LEN; i += 1) {
                         if ((i % 64) == 1)
                                 bsg_pr_test_info("%s: Have written and read back %4zu words\n",
                                                  __func__, i);
                         
                         hb_mc_npa_t npa = hb_mc_npa_from_x_y(dram_coord_x,
                                                              dram_coord_y,
-                                                             BASE_ADDR+i);
+                                                             BASE_ADDR+(i << 2));
                         write_data = rand();
                         err = hb_mc_manycore_write_mem(mc, &npa, &write_data, sizeof(write_data));
                         if (err != HB_MC_SUCCESS) {
@@ -85,7 +85,7 @@ int test_manycore_vcache_sequence() {
                                            " to DRAM coord (%d,%d) @ 0x08%" PRIx32 ": %s\n",
                                            __func__, i, write_data,
                                            dram_coord_x, dram_coord_y,
-                                           (npa.epa+i) << 2,
+                                           (npa.epa+ (i << 2)) << 2,
                                            hb_mc_strerror(err));
                                 goto cleanup;
                         }
@@ -96,7 +96,7 @@ int test_manycore_vcache_sequence() {
                                            "from DRAM coord (%d,%d) @ 0x%08" PRIx32 ": %s\n",
                                            __func__, i,
                                            dram_coord_x, dram_coord_y,
-                                           (npa.epa+i) << 2,
+                                           (npa.epa+ (i << 2)) << 2,
                                            hb_mc_strerror(err));
                                 goto cleanup;
                         }
@@ -112,6 +112,56 @@ int test_manycore_vcache_sequence() {
                         
                         mismatch = mismatch || !data_match;
                 }
+
+
+                // Write a 4-byte word into mis-aligned addresses to 
+                // verify that API returns an invalid address error
+                hb_mc_npa_t npa = hb_mc_npa_from_x_y(dram_coord_x,
+                                                     dram_coord_y,
+                                                     BASE_ADDR+ 1);
+                write_data = rand();
+                err = hb_mc_manycore_write_mem(mc, &npa, &write_data, sizeof(write_data));
+                if (err != HB_MC_SUCCESS) { 
+                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
+                        bsg_pr_err("%s: Did not catch write into invalid mis-alined address: 0x%08" PRIx32 ".\n",
+                                   __func__, hb_mc_npa_get_epa(&npa));
+
+                }
+                else {
+                        bsg_pr_err("%s: Did not catch write into invalid mis-alined address: 0x%08" PRIx32 ".\n",
+                                   __func__, npa);
+                        return HB_MC_FAIL;
+                }
+
+                npa = hb_mc_npa_from_x_y(dram_coord_x,
+                                         dram_coord_y,
+                                         BASE_ADDR+ 2);
+                write_data = rand();
+                err = hb_mc_manycore_write_mem(mc, &npa, &write_data, sizeof(write_data));
+                if (err != HB_MC_SUCCESS) {
+                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
+                } 
+                else {
+                        bsg_pr_err("%s: Did not catch write into invalid mis-alined address: 0x%08" PRIx32 ".\n",
+                                   __func__, hb_mc_npa_get_epa(&npa));
+                        return HB_MC_FAIL;
+                }
+
+                npa = hb_mc_npa_from_x_y(dram_coord_x,
+                                         dram_coord_y,
+                                         BASE_ADDR+ 3);
+                write_data = rand();
+                err = hb_mc_manycore_write_mem(mc, &npa, &write_data, sizeof(write_data));
+                if (err != HB_MC_SUCCESS) {
+                        bsg_pr_test_info("%s: Expected an invalid address error. We're good!\n", __func__);
+                }
+                else {
+                        bsg_pr_err("%s: Did not catch write into invalid mis-alined address: 0x%08" PRIx32 ".\n",
+                                   __func__, hb_mc_npa_get_epa(&npa));
+                        return HB_MC_FAIL;
+                }
+
+
         }
 
         /********************************/

--- a/regression/library/tests.mk
+++ b/regression/library/tests.mk
@@ -43,6 +43,7 @@ INDEPENDENT_TESTS += test_vcache_simplified
 INDEPENDENT_TESTS += test_vcache_stride
 INDEPENDENT_TESTS += test_vcache_sequence
 INDEPENDENT_TESTS += test_printing
+INDEPENDENT_TESTS += test_manycore_alignment
 INDEPENDENT_TESTS += test_manycore_packets
 INDEPENDENT_TESTS += test_manycore_init
 INDEPENDENT_TESTS += test_manycore_dmem_read_write


### PR DESCRIPTION
Related to issue #477 .
credit to @save-buffer and @drichmond.
- Added hb_mc_epa_check_alignment function to check for correct address alignment based on size.
- Moved all alignment functions in hb_mc_manycore_write8/16/32, hb_mc_manycore_write_mem, and hb_mc_manycore_memset function down one level to hb_mc_manycore_write function
- Modified test_manycore_vcache_sequence test write into correctly aligned addresses, and added writes to misaligned addresses to make sure the HOST API catches them.
COSIM regression passed, ready to merge.
