### PR TITLE
Fix for 483

### DIFF
--- a/libraries/bsg_manycore.cpp
+++ b/libraries/bsg_manycore.cpp
@@ -61,6 +61,7 @@
 #include <assert.h>
 #endif
 
+#include <type_traits>
 #include <stack>
 #include <queue>
 #include <vector>
@@ -1376,6 +1377,16 @@ static UINT hb_mc_manycore_mask_load_data(const hb_mc_npa_t *npa, uint32_t load_
 {
         int shift = CHAR_BIT * (hb_mc_npa_get_epa(npa) & 0x3);
         uint32_t result;
+
+        /* make sure this template is being used only as intended */
+        static_assert(std::is_unsigned<UINT>::value,
+                      "hb_mc_manycore_mask_load_data: UINT must be uint8_t, uint16_t, or uint32_t");
+
+        static_assert(std::is_integral<UINT>::value,
+                      "hb_mc_manycore_mask_load_data: UINT must be uint8_t, uint16_t, or uint32_t");
+
+        static_assert(sizeof(UINT) == 1 || sizeof(UINT) == 2 || sizeof(UINT) == 4,
+                      "hb_mc_manycore_mask_load_data: UINT must be uint8_t, uint16_t, or uint32_t");
 
         if (sizeof(UINT) == 4) {
                 result = load_data;

--- a/libraries/bsg_manycore.cpp
+++ b/libraries/bsg_manycore.cpp
@@ -1405,15 +1405,18 @@ static int hb_mc_manycore_read(hb_mc_manycore_t *mc, const hb_mc_npa_t *npa, UIN
 {
         int err;
 
+        /* send load request */
         err = hb_mc_manycore_send_read_rqst(mc, npa, sizeof(UINT));
         if (err != HB_MC_SUCCESS)
                 return err;
 
+        /* read back response */
         uint32_t load_data;
         err = hb_mc_manycore_recv_read_rsp(mc, &load_data);
         if (err != HB_MC_SUCCESS)
                 return err;
 
+        /* mask off unused bits */
         *vp = hb_mc_manycore_mask_load_data<UINT>(npa, load_data);
         return HB_MC_SUCCESS;
 }

--- a/libraries/bsg_manycore.cpp
+++ b/libraries/bsg_manycore.cpp
@@ -1363,8 +1363,16 @@ static int hb_mc_manycore_recv_read_rsp(hb_mc_manycore_t *mc,
         }
 
         /* check that the npa matches? */
-        
-        int shift = CHAR_BIT * (hb_mc_npa_get_epa(npa) & 0x3);
+        int shift;
+        if (sz == 2 || sz == 1) {
+                if (npa == nullptr) {
+                        manycore_pr_err(mc,"%s: Non-blocking loads only supported for 32bit values",
+                                        __func__);
+                        return HB_MC_NOIMPL;
+                }
+                shift = CHAR_BIT * (hb_mc_npa_get_epa(npa) & 0x3);
+        }
+
         /* read data from packet */
         switch (sz) {
         case 4:


### PR DESCRIPTION
* fixes #483
* decouples reading response packets from the masking of response data