### PR TITLE
Add -Wall and -Werror to cosimulation compile flags

### DIFF
--- a/regression/cuda/tests.mk
+++ b/regression/cuda/tests.mk
@@ -85,6 +85,6 @@ DEFINES += -D_XOPEN_SOURCE=500 -D_BSD_SOURCE
 CDEFINES   += $(DEFINES)
 CXXDEFINES += $(DEFINES)
 
-FLAGS     = -g -Wall
+FLAGS     = -g -Wall -Werror
 CFLAGS   += -std=c99 $(FLAGS) 
 CXXFLAGS += -std=c++11 $(FLAGS)

--- a/regression/library/tests.mk
+++ b/regression/library/tests.mk
@@ -61,6 +61,6 @@ DEFINES += -D_XOPEN_SOURCE=500 -D_BSD_SOURCE
 CDEFINES   += $(DEFINES)
 CXXDEFINES += $(DEFINES)
 
-FLAGS     = -g -Wall
+FLAGS     = -g -Wall -Werror
 CFLAGS   += -std=c99 $(FLAGS) 
 CXXFLAGS += -std=c++11 $(FLAGS)

--- a/regression/python/tests.mk
+++ b/regression/python/tests.mk
@@ -46,7 +46,7 @@ DEFINES += -D_XOPEN_SOURCE=500 -D_BSD_SOURCE
 CDEFINES   += $(DEFINES)
 CXXDEFINES += $(DEFINES)
 
-FLAGS     = -g -Wall $(shell python3.6-config --cflags) -O1 
+FLAGS     = -g -Wall $(shell python3.6-config --cflags) -O1  -Werror
 CFLAGS   += -std=c99 $(FLAGS)
 CXXFLAGS += -std=c++11 $(FLAGS) 
 LDFLAGS  += $(shell python3.6-config --ldflags) 

--- a/regression/specint/tests.mk
+++ b/regression/specint/tests.mk
@@ -54,7 +54,7 @@ DEFINES += -D_XOPEN_SOURCE=500 -D_BSD_SOURCE
 CDEFINES   += $(DEFINES)
 CXXDEFINES += $(DEFINES)
 
-FLAGS     = -g -Wall
+FLAGS     = -g -Wall -Werror
 CFLAGS   += -std=c11 $(FLAGS) 
 CXXFLAGS += -std=c++11 $(FLAGS)
 LDFLAGS  += -lbsg_manycore_runtime -lm

--- a/regression/spmd/tests.mk
+++ b/regression/spmd/tests.mk
@@ -55,6 +55,6 @@ DEFINES += -D_XOPEN_SOURCE=500 -D_BSD_SOURCE
 CDEFINES   += $(DEFINES)
 CXXDEFINES += $(DEFINES)
 
-FLAGS     = -g -Wall
+FLAGS     = -g -Wall -Werror
 CFLAGS   += -std=c11 $(FLAGS) 
 CXXFLAGS += -std=c++11 $(FLAGS)

--- a/testbenches/compilation.mk
+++ b/testbenches/compilation.mk
@@ -170,7 +170,7 @@ $(EXEC_PATH)/%: $(SRC_PATH)/%.c $(CSOURCES) $(CHEADERS) $(SIMLIBS)
 
 $(EXEC_PATH)/%: $(SRC_PATH)/%.cpp $(CXXSOURCES) $(CXXHEADERS) $(SIMLIBS)
 	SYNOPSYS_SIM_SETUP=$(TESTBENCH_PATH)/synopsys_sim.setup \
-	vcs tb glbl -j$(NPROCS) $(WRAPPER_NAME) $< -Mdirectory=$@.tmp \
+	vcs tb glbl -cc g++ -j$(NPROCS) $(WRAPPER_NAME) $< -Mdirectory=$@.tmp \
 		$(VCS_CXXFLAGS) $(VCS_CXXDEFINES) $(VCS_INCLUDES) $(VCS_LDFLAGS) \
 		$(VCS_VFLAGS) -o $@ -l $@.vcs.log
 

--- a/testbenches/sh_dpi_tasks.svh
+++ b/testbenches/sh_dpi_tasks.svh
@@ -58,7 +58,7 @@ import tb_type_defines_pkg::*;
       tb.card.fpga.sh.map_host_memory(addr);
    endtask
 
-   task cl_peek(input longint unsigned addr, output int unsigned data);
+   task cl_peek(input longint unsigned addr, output longint unsigned data);
       tb.card.fpga.sh.peek(.addr(addr), .data(data), .intf(AxiPort::PORT_OCL));
    endtask
    
@@ -74,7 +74,7 @@ import tb_type_defines_pkg::*;
       repeat (x) #1us;
    endtask
 
-   task sv_fpga_pci_peek(input int handle, input longint unsigned offset, output int unsigned value);
+   task sv_fpga_pci_peek(input int handle, input longint unsigned offset, output longint unsigned value);
       tb.card.fpga.sh.peek(.addr(offset), .data(value), .intf(AxiPort::PORT_OCL));
    endtask
    


### PR DESCRIPTION
This PR adds -Wall and -Werror to compile flags.

However, I'm not entirely comfortable with the changes that were necessary (though simple)

To summarize: 
* VCS doesn't have a CXXFLAGS option, only CFLAGS
* VCS uses gcc by default as its compiler to compile c-generated source files
* VCS must use g++ not gcc avoid compile-time errors
* VCS generated C source isn't C++ compliant (typecasting from int* to unsigned int*)

Therefore, the solution is to modify the DPI interface slightly (using longint unsigned instead of unsigned int), which triggers a void* instead of an int* (when we wanted an unsigned int*)

This passes cosimulation, but I am fairly leery about this PR until @mrutt92 and I talk it through.

(Adding @dpetrisko for input on Verilog types) 

