### PR TITLE
Make Flow modifications

### DIFF
--- a/Makefile.machine.include
+++ b/Makefile.machine.include
@@ -38,7 +38,9 @@ BSG_MACHINE_DRAM_SIZE_WORDS           = 536870912
 BSG_MACHINE_DRAM_BANK_SIZE_WORDS      = 134217728
 
 BSG_MACHINE_DATA_WIDTH                = 32
-BSG_MANYCORE_MACHINE_NAME             := Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)_NB_DDR
+
+# BSG Machine Name is used to build non-conflicting crt.o files
+BSG_MACHINE_NAME                      = Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)_NONBLK_DDR4_F1MODEL
 
 # This flag has to be always 0 by default. Conditional
 # assignment allows user to set this flag through

--- a/Makefile.machine.include
+++ b/Makefile.machine.include
@@ -38,6 +38,7 @@ BSG_MACHINE_DRAM_SIZE_WORDS           = 536870912
 BSG_MACHINE_DRAM_BANK_SIZE_WORDS      = 134217728
 
 BSG_MACHINE_DATA_WIDTH                = 32
+BSG_MANYCORE_MACHINE_NAME             := Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)_NB_DDR
 
 # This flag has to be always 0 by default. Conditional
 # assignment allows user to set this flag through

--- a/Makefile.machine.include
+++ b/Makefile.machine.include
@@ -39,9 +39,6 @@ BSG_MACHINE_DRAM_BANK_SIZE_WORDS      = 134217728
 
 BSG_MACHINE_DATA_WIDTH                = 32
 
-# BSG Machine Name is used to build non-conflicting crt.o files
-BSG_MACHINE_NAME                      = Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)_NONBLK_DDR4_F1MODEL
-
 # This flag has to be always 0 by default. Conditional
 # assignment allows user to set this flag through
 # environment when required.
@@ -52,4 +49,8 @@ CL_MANYCORE_HOST_COORD_Y             := 0
 CL_MANYCORE_DIM_X                    := $(BSG_MACHINE_GLOBAL_X)
 CL_MANYCORE_DIM_Y                    := $(shell expr $(BSG_MACHINE_GLOBAL_Y) - 1)
 
-CL_MANYCORE_MEM_CFG                  := e_vcache_non_blocking_axi4_f1_model
+CL_MANYCORE_MEM_CFG                  :=e_vcache_non_blocking_axi4_f1_model
+
+# Define BSG_MACHINE_NAME using the Y and X dimensions, and CL_MANYCORE_MEM_CFG
+BSG_MACHINE_NAME                      =Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)
+BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)

--- a/libraries/libraries.mk
+++ b/libraries/libraries.mk
@@ -25,89 +25,83 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-INCLUDES += -I$(LIBRARIES_PATH)
+LIB_CSOURCES   += 
+LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore.cpp
+LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_bits.cpp
+LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_config.cpp
+LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_cuda.cpp
+LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_elf.cpp
+LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_eva.cpp
+LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_loader.cpp
+LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_memory_manager.cpp
+LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_origin_eva_map.cpp
+LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_print_int_responder.cpp
+LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_printing.cpp
+LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_request_packet_id.cpp
+LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_responder.cpp
+LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_tile.cpp
+LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_uart_responder.cpp
+LIB_CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_trace_responder.cpp
 
-CSOURCES   += 
-CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore.cpp
-CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_bits.cpp
-CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_config.cpp
-CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_cuda.cpp
-CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_elf.cpp
-CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_eva.cpp
-CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_loader.cpp
-CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_memory_manager.cpp
-CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_origin_eva_map.cpp
-CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_print_int_responder.cpp
-CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_printing.cpp
-CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_request_packet_id.cpp
-CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_responder.cpp
-CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_tile.cpp
-CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_uart_responder.cpp
-CXXSOURCES += $(LIBRARIES_PATH)/bsg_manycore_trace_responder.cpp
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_bits.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_config.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_cuda.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_elf.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_eva.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_loader.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_memory_manager.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_origin_eva_map.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_printing.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_request_packet_id.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_responder.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_tile.h
 
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_bits.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_config.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_cuda.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_elf.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_eva.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_loader.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_memory_manager.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_origin_eva_map.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_printing.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_request_packet_id.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_responder.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_tile.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_vcache.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_mmio.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_errno.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_features.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_coordinate.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_npa.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_epa.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_packet.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_response_packet.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_request_packet.h
+LIB_HEADERS += $(LIBRARIES_PATH)/bsg_manycore_fifo.h
 
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_vcache.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_mmio.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_errno.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_features.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_coordinate.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_npa.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_epa.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_packet.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_response_packet.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_request_packet.h
-HEADERS += $(LIBRARIES_PATH)/bsg_manycore_fifo.h
+LIB_OBJECTS += $(patsubst %cpp,%o,$(LIB_CXXSOURCES))
+LIB_OBJECTS += $(patsubst %c,%o,$(LIB_CSOURCES))
 
-CHEADERS   += $(HEADERS)
-CXXHEADERS += $(HEADERS)
-
-OBJECTS += $(patsubst %cpp,%o,$(CXXSOURCES))
-OBJECTS += $(patsubst %c,%o,$(CSOURCES))
-
-$(OBJECTS): INCLUDES  = -I$(LIBRARIES_PATH)
-$(OBJECTS): INCLUDES += -I$(SDK_DIR)/userspace/include
-$(OBJECTS): INCLUDES += -I$(HDK_DIR)/common/software/include
-$(OBJECTS): INCLUDES += -I$(AWS_FPGA_REPO_DIR)/SDAccel/userspace/include
-$(OBJECTS): CFLAGS    = -std=c11 -fPIC -D_GNU_SOURCE $(INCLUDES)
-$(OBJECTS): CXXFLAGS  = -std=c++11 -fPIC -D_GNU_SOURCE $(INCLUDES)
-$(OBJECTS): LDFLAGS   = -lfpga_mgmt -fPIC
-$(OBJECTS): $(HEADERS)
+$(LIB_OBJECTS): INCLUDES  = -I$(LIBRARIES_PATH)
+$(LIB_OBJECTS): INCLUDES += -I$(SDK_DIR)/userspace/include
+$(LIB_OBJECTS): INCLUDES += -I$(HDK_DIR)/common/software/include
+$(LIB_OBJECTS): INCLUDES += -I$(AWS_FPGA_REPO_DIR)/SDAccel/userspace/include
+$(LIB_OBJECTS): CFLAGS    = -std=c11 -fPIC -D_GNU_SOURCE $(INCLUDES)
+$(LIB_OBJECTS): CXXFLAGS  = -std=c++11 -fPIC -D_GNU_SOURCE $(INCLUDES)
+$(LIB_OBJECTS): LDFLAGS   = -lfpga_mgmt -fPIC
 
 # Objects that should be compiled with debug flags
-DEBUG_OBJECTS  +=
-#DEBUG_OBJECTS  += $(LIBRARIES_PATH)/bsg_manycore_responder.o
-#DEBUG_OBJECTS  += $(LIBRARIES_PATH)/bsg_manycore_uart_responder.o
-$(DEBUG_OBJECTS):  CXXFLAGS += -DDEBUG
+LIB_DEBUG_OBJECTS  +=
+#LIB_DEBUG_OBJECTS  += $(LIBRARIES_PATH)/bsg_manycore_responder.o
+#LIB_DEBUG_OBJECTS  += $(LIBRARIES_PATH)/bsg_manycore_uart_responder.o
+$(LIB_DEBUG_OBJECTS):  CXXFLAGS += -DDEBUG
 
 # Objects that should be compiled with strict compilation flags
-STRICT_OBJECTS +=
-STRICT_OBJECTS += $(LIBRARIES_PATH)/bsg_manycore_responder.o
-STRICT_OBJECTS += $(LIBRARIES_PATH)/bsg_manycore_loader.o
-STRICT_OBJECTS += $(LIBRARIES_PATH)/bsg_manycore_packet_id.o
-STRICT_OBJECTS += $(LIBRARIES_PATH)/bsg_manycore_eva.o
-STRICT_OBJECTS += $(LIBRARIES_PATH)/bsg_manycore_origin_eva_map.o
-STRICT_OBJECTS += $(LIBRARIES_PATH)/bsg_manycore_print_int_responder.o
-$(STRICT_OBJECTS): CXXFLAGS += -Wall -Werror
-$(STRICT_OBJECTS): CXXFLAGS += -Wno-unused-variable
-$(STRICT_OBJECTS): CXXFLAGS += -Wno-unused-function
-$(STRICT_OBJECTS): CXXFLAGS += -Wno-unused-but-set-variable
+LIB_STRICT_OBJECTS +=
+LIB_STRICT_OBJECTS += $(LIBRARIES_PATH)/bsg_manycore_responder.o
+LIB_STRICT_OBJECTS += $(LIBRARIES_PATH)/bsg_manycore_loader.o
+LIB_STRICT_OBJECTS += $(LIBRARIES_PATH)/bsg_manycore_packet_id.o
+LIB_STRICT_OBJECTS += $(LIBRARIES_PATH)/bsg_manycore_eva.o
+LIB_STRICT_OBJECTS += $(LIBRARIES_PATH)/bsg_manycore_origin_eva_map.o
+LIB_STRICT_OBJECTS += $(LIBRARIES_PATH)/bsg_manycore_print_int_responder.o
+$(LIB_STRICT_OBJECTS): CXXFLAGS += -Wall -Werror
+$(LIB_STRICT_OBJECTS): CXXFLAGS += -Wno-unused-variable
+$(LIB_STRICT_OBJECTS): CXXFLAGS += -Wno-unused-function
+$(LIB_STRICT_OBJECTS): CXXFLAGS += -Wno-unused-but-set-variable
 
 $(LIBRARIES_PATH)/libbsg_manycore_runtime.so.1.0: LD = $(CXX)
 $(LIBRARIES_PATH)/libbsg_manycore_runtime.so.1.0: LDFLAGS = -lfpga_mgmt -fPIC
-$(LIBRARIES_PATH)/libbsg_manycore_runtime.so.1.0: $(OBJECTS)
+$(LIBRARIES_PATH)/libbsg_manycore_runtime.so.1.0: $(LIB_OBJECTS) $(HEADERS)
 	$(LD) -shared -Wl,-soname,$(basename $(notdir $@)) -o $@ $^ $(LDFLAGS)
 
 .PHONY: libraries.clean

--- a/machines/4x16_non_blocking_vcache_ramulator_hbm/Makefile.machine.include
+++ b/machines/4x16_non_blocking_vcache_ramulator_hbm/Makefile.machine.include
@@ -39,9 +39,6 @@ BSG_MACHINE_DRAM_BANK_SIZE_WORDS      = 67108864
 
 BSG_MACHINE_DATA_WIDTH                = 32
 
-# BSG Machine Name is used to build non-conflicting crt.o files
-BSG_MACHINE_NAME                      = Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)_NONBLK_HBM_RAMULATOR
-
 # This flag has to be always 0 by default. Conditional
 # assignment allows user to set this flag through
 # environment when required.
@@ -53,3 +50,7 @@ CL_MANYCORE_DIM_X                    := $(BSG_MACHINE_GLOBAL_X)
 CL_MANYCORE_DIM_Y                    := $(shell expr $(BSG_MACHINE_GLOBAL_Y) - 1)
 
 CL_MANYCORE_MEM_CFG                  := e_vcache_non_blocking_ramulator_hbm
+
+# Define BSG_MACHINE_NAME using the Y and X dimensions, and CL_MANYCORE_MEM_CFG
+BSG_MACHINE_NAME                      =Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)
+BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)

--- a/machines/4x16_non_blocking_vcache_ramulator_hbm/Makefile.machine.include
+++ b/machines/4x16_non_blocking_vcache_ramulator_hbm/Makefile.machine.include
@@ -39,6 +39,9 @@ BSG_MACHINE_DRAM_BANK_SIZE_WORDS      = 67108864
 
 BSG_MACHINE_DATA_WIDTH                = 32
 
+# BSG Machine Name is used to build non-conflicting crt.o files
+BSG_MACHINE_NAME                      = Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)_NONBLK_HBM_RAMULATOR
+
 # This flag has to be always 0 by default. Conditional
 # assignment allows user to set this flag through
 # environment when required.

--- a/machines/4x32_non_blocking_vcache_ramulator_hbm/Makefile.machine.include
+++ b/machines/4x32_non_blocking_vcache_ramulator_hbm/Makefile.machine.include
@@ -39,9 +39,6 @@ BSG_MACHINE_DRAM_BANK_SIZE_WORDS      = 33554432
 
 BSG_MACHINE_DATA_WIDTH                = 32
 
-# BSG Machine Name is used to build non-conflicting crt.o files
-BSG_MACHINE_NAME                      = Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)_NONBLK_HBM_RAMULATOR
-
 # This flag has to be always 0 by default. Conditional
 # assignment allows user to set this flag through
 # environment when required.
@@ -53,3 +50,7 @@ CL_MANYCORE_DIM_X                    := $(BSG_MACHINE_GLOBAL_X)
 CL_MANYCORE_DIM_Y                    := $(shell expr $(BSG_MACHINE_GLOBAL_Y) - 1)
 
 CL_MANYCORE_MEM_CFG                  := e_vcache_non_blocking_ramulator_hbm
+
+# Define BSG_MACHINE_NAME using the Y and X dimensions, and CL_MANYCORE_MEM_CFG
+BSG_MACHINE_NAME                      =Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)
+BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)

--- a/machines/4x32_non_blocking_vcache_ramulator_hbm/Makefile.machine.include
+++ b/machines/4x32_non_blocking_vcache_ramulator_hbm/Makefile.machine.include
@@ -39,6 +39,9 @@ BSG_MACHINE_DRAM_BANK_SIZE_WORDS      = 33554432
 
 BSG_MACHINE_DATA_WIDTH                = 32
 
+# BSG Machine Name is used to build non-conflicting crt.o files
+BSG_MACHINE_NAME                      = Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)_NONBLK_HBM_RAMULATOR
+
 # This flag has to be always 0 by default. Conditional
 # assignment allows user to set this flag through
 # environment when required.

--- a/machines/4x4_blocking_vcache_f1_model/Makefile.machine.include
+++ b/machines/4x4_blocking_vcache_f1_model/Makefile.machine.include
@@ -39,6 +39,9 @@ BSG_MACHINE_DRAM_BANK_SIZE_WORDS      = 134217728
 
 BSG_MACHINE_DATA_WIDTH                = 32
 
+# BSG Machine Name is used to build non-conflicting crt.o files
+BSG_MACHINE_NAME                      = Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)_BLK_DDR4_F1MODEL
+
 # This flag has to be always 0 by default. Conditional
 # assignment allows user to set this flag through
 # environment when required.

--- a/machines/4x4_blocking_vcache_f1_model/Makefile.machine.include
+++ b/machines/4x4_blocking_vcache_f1_model/Makefile.machine.include
@@ -39,9 +39,6 @@ BSG_MACHINE_DRAM_BANK_SIZE_WORDS      = 134217728
 
 BSG_MACHINE_DATA_WIDTH                = 32
 
-# BSG Machine Name is used to build non-conflicting crt.o files
-BSG_MACHINE_NAME                      = Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)_BLK_DDR4_F1MODEL
-
 # This flag has to be always 0 by default. Conditional
 # assignment allows user to set this flag through
 # environment when required.
@@ -53,3 +50,7 @@ CL_MANYCORE_DIM_X                    := $(BSG_MACHINE_GLOBAL_X)
 CL_MANYCORE_DIM_Y                    := $(shell expr $(BSG_MACHINE_GLOBAL_Y) - 1)
 
 CL_MANYCORE_MEM_CFG                  := e_vcache_blocking_axi4_f1_model
+
+# Define BSG_MACHINE_NAME using the Y and X dimensions, and CL_MANYCORE_MEM_CFG
+BSG_MACHINE_NAME                      =Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)
+BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)

--- a/machines/4x8_non_blocking_dramsim3_hbm2_4gb/Makefile.machine.include
+++ b/machines/4x8_non_blocking_dramsim3_hbm2_4gb/Makefile.machine.include
@@ -39,9 +39,6 @@ BSG_MACHINE_DRAM_BANK_SIZE_WORDS      = 134217728
 
 BSG_MACHINE_DATA_WIDTH                = 32
 
-# BSG Machine Name is used to build non-conflicting crt.o files
-BSG_MACHINE_NAME                      = Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)_NONBLK_HBM_DRAMSIM3
-
 # This flag has to be always 0 by default. Conditional
 # assignment allows user to set this flag through
 # environment when required.
@@ -53,3 +50,7 @@ CL_MANYCORE_DIM_X                    := $(BSG_MACHINE_GLOBAL_X)
 CL_MANYCORE_DIM_Y                    := $(shell expr $(BSG_MACHINE_GLOBAL_Y) - 1)
 
 CL_MANYCORE_MEM_CFG                  := e_vcache_non_blocking_dramsim3_hbm2_4gb_x128
+
+# Define BSG_MACHINE_NAME using the Y and X dimensions, and CL_MANYCORE_MEM_CFG
+BSG_MACHINE_NAME                      =Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)
+BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)

--- a/machines/4x8_non_blocking_dramsim3_hbm2_4gb/Makefile.machine.include
+++ b/machines/4x8_non_blocking_dramsim3_hbm2_4gb/Makefile.machine.include
@@ -39,6 +39,9 @@ BSG_MACHINE_DRAM_BANK_SIZE_WORDS      = 134217728
 
 BSG_MACHINE_DATA_WIDTH                = 32
 
+# BSG Machine Name is used to build non-conflicting crt.o files
+BSG_MACHINE_NAME                      = Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)_NONBLK_HBM_DRAMSIM3
+
 # This flag has to be always 0 by default. Conditional
 # assignment allows user to set this flag through
 # environment when required.

--- a/machines/4x8_non_blocking_vcache_ramulator_hbm/Makefile.machine.include
+++ b/machines/4x8_non_blocking_vcache_ramulator_hbm/Makefile.machine.include
@@ -39,9 +39,6 @@ BSG_MACHINE_DRAM_BANK_SIZE_WORDS      = 134217728
 
 BSG_MACHINE_DATA_WIDTH                = 32
 
-# BSG Machine Name is used to build non-conflicting crt.o files
-BSG_MACHINE_NAME                      = Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)_NONBLK_HBM_RAMULATOR
-
 # This flag has to be always 0 by default. Conditional
 # assignment allows user to set this flag through
 # environment when required.
@@ -53,3 +50,7 @@ CL_MANYCORE_DIM_X                    := $(BSG_MACHINE_GLOBAL_X)
 CL_MANYCORE_DIM_Y                    := $(shell expr $(BSG_MACHINE_GLOBAL_Y) - 1)
 
 CL_MANYCORE_MEM_CFG                  := e_vcache_non_blocking_ramulator_hbm
+
+# Define BSG_MACHINE_NAME using the Y and X dimensions, and CL_MANYCORE_MEM_CFG
+BSG_MACHINE_NAME                      =Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)
+BSG_MACHINE_NAME                     :=$(BSG_MACHINE_NAME)_$(CL_MANYCORE_MEM_CFG:e_%=%)

--- a/machines/4x8_non_blocking_vcache_ramulator_hbm/Makefile.machine.include
+++ b/machines/4x8_non_blocking_vcache_ramulator_hbm/Makefile.machine.include
@@ -39,6 +39,9 @@ BSG_MACHINE_DRAM_BANK_SIZE_WORDS      = 134217728
 
 BSG_MACHINE_DATA_WIDTH                = 32
 
+# BSG Machine Name is used to build non-conflicting crt.o files
+BSG_MACHINE_NAME                      = Y$(BSG_MACHINE_GLOBAL_Y)X$(BSG_MACHINE_GLOBAL_X)_NONBLK_HBM_RAMULATOR
+
 # This flag has to be always 0 by default. Conditional
 # assignment allows user to set this flag through
 # environment when required.

--- a/regression/compilation.mk
+++ b/regression/compilation.mk
@@ -35,10 +35,6 @@ NC=\033[0m
 # This file REQUIRES several variables to be set. They are typically
 # set by the Makefile that includes this makefile..
 # 
-# REGRESSION_TESTS: Names of all available regression tests.
-ifndef REGRESSION_TESTS
-$(error $(shell echo -e "$(RED)BSG MAKE ERROR: REGRESSION_TESTS is not defined$(NC)"))
-endif
 
 # SRC_PATH: The path to the directory where tests will be executed
 ifndef SRC_PATH
@@ -53,15 +49,6 @@ endif
 # ... or a .cpp and .hpp of the same name
 %.o: %.cpp %.hpp
 	$(CXX) -c -o $@ $< $(INCLUDES) $(CXXFLAGS) $(CXXDEFINES) -DBSG_TEST_NAME=$(patsubst %.cpp,%,$<) 
-
-# To include a test in regression, the user defines a list of tests in
-# REGRESSION_TESTS. Each test can also define a custom rule, <test_name>.rule
-# that is run during compilation. These custom rules are useful for building
-# spmd or cuda binaries, for example.
-USER_RULES:=$(addsuffix .rule,$(REGRESSION_TESTS))
-$(USER_RULES):
-USER_CLEAN_RULES=$(addsuffix .clean,$(REGRESSION_TESTS))
-$(USER_CLEAN_RULES):
 
 compilation.clean: 
 	rm -rf $(foreach tgt, $(INDEPENDENT_TESTS), $(SRC_PATH)/$(tgt).o) $(SRC_PATH)/test_loader.o

--- a/regression/regression.mk
+++ b/regression/regression.mk
@@ -50,6 +50,15 @@ LOG_RULES = $(addsuffix .log,$(REGRESSION_TESTS))
 LOG_TARGETS =$(addprefix $(EXEC_PATH)/,$(LOG_RULES))
 $(LOG_RULES): %: $(EXEC_PATH)/%
 
+# To include a test in regression, the user defines a list of tests in
+# REGRESSION_TESTS. Each test can also define a custom rule, <test_name>.rule
+# that is run during compilation. These custom rules are useful for building
+# spmd or cuda binaries, for example.
+USER_RULES:=$(addsuffix .rule,$(REGRESSION_TESTS))
+$(USER_RULES):
+USER_CLEAN_RULES=$(addsuffix .clean,$(REGRESSION_TESTS))
+$(USER_CLEAN_RULES):
+
 # The regression target runs all of the tests in the REGRESSION_TESTS variable
 # for a directory.
 regression: $(EXEC_PATH)/regression.log 

--- a/testbenches/cosimulation.mk
+++ b/testbenches/cosimulation.mk
@@ -81,6 +81,9 @@ help:
 	@echo "             generate the vanilla log file"
 	@echo "      clean: Remove all subdirectory-specific outputs"
 
+$(REGRESSION_TESTS): %: $(EXEC_PATH)/%
+test_loader: %: $(EXEC_PATH)/%
+
 VPD_RULES = $(addsuffix .vpd,$(REGRESSION_TESTS))
 $(VPD_RULES): SIM_ARGS +=+trace
 $(VPD_RULES): %.vpd: %.log
@@ -96,3 +99,4 @@ $(VANILLA_LOG_RULES): %.vanilla.log: $(EXEC_PATH)/%.log
 clean: regression.clean compilation.clean link.clean $(USER_CLEAN_RULES)
 	rm -rf *.log
 	rm -rf *.vanilla_operation_trace.csv *.vanilla_stats.csv
+	rm -rf $(REGRESSION_TESTS) test_loader

--- a/testbenches/link.mk
+++ b/testbenches/link.mk
@@ -35,10 +35,6 @@ NC=\033[0m
 # This file REQUIRES several variables to be set. They are typically
 # set by the Makefile that includes this fragment...
 # 
-# REGRESSION_TESTS: Names of all available regression tests.
-ifndef REGRESSION_TESTS
-$(error $(shell echo -e "$(RED)BSG MAKE ERROR: REGRESSION_TESTS is not defined$(NC)"))
-endif
 
 # SRC_PATH: The path to the directory containing the .c or cpp test files
 ifndef SRC_PATH
@@ -58,11 +54,6 @@ endif
 # TESTBENCH_PATH: The path to the testbenches folder in BSG F1
 ifndef TESTBENCH_PATH
 $(error $(shell echo -e "$(RED)BSG MAKE ERROR: TESTBENCH_PATH is not defined$(NC)"))
-endif
-
-# REGRESSION_PATH: The path to the regression folder in BSG F1
-ifndef REGRESSION_PATH
-$(error $(shell echo -e "$(RED)BSG MAKE ERROR: REGRESSION_PATH is not defined$(NC)"))
 endif
 
 # The following makefile fragment verifies that the tools and CAD environment is
@@ -110,13 +101,11 @@ VCS_VFLAGS    += -debug_pp
 VCS_VFLAGS    += +memcbk 
 endif
 
-$(REGRESSION_TESTS): %: $(EXEC_PATH)/%
-test_loader: %: $(EXEC_PATH)/%
-
 # VCS Generates an executable file by linking against the
 # $(SRC_PATH)/%.c or $(SRC_PATH)/%.o $(SRC_PATH)/%.cpp file that
 # corresponds to the target test in the $(SRC_PATH) directory.
-$(EXEC_PATH)/%: $(SRC_PATH)/%.o $(SIMLIBS)
+$(EXEC_PATH)/%: $(SRC_PATH)/%.o $(OBJECTS) $(SIMLIBS)
+	@echo $(OBJECTS)
 	SYNOPSYS_SIM_SETUP=$(TESTBENCH_PATH)/synopsys_sim.setup \
 	vcs tb glbl -j$(NPROCS) $(WRAPPER_NAME) $< -Mdirectory=$@.tmp \
 		$(VCS_LDFLAGS) $(VCS_VFLAGS) -o $@ -l $@.vcs.log
@@ -129,4 +118,4 @@ link.clean:
 	rm -rf $(EXEC_PATH)/*.key $(EXEC_PATH)/*.vpd
 	rm -rf $(EXEC_PATH)/vc_hdrs.h
 	rm -rf .vlogansetup* stack.info*
-	rm -rf $(REGRESSION_TESTS) test_loader
+

--- a/testbenches/link.mk
+++ b/testbenches/link.mk
@@ -104,8 +104,7 @@ endif
 # VCS Generates an executable file by linking against the
 # $(SRC_PATH)/%.c or $(SRC_PATH)/%.o $(SRC_PATH)/%.cpp file that
 # corresponds to the target test in the $(SRC_PATH) directory.
-$(EXEC_PATH)/%: $(SRC_PATH)/%.o $(OBJECTS) $(SIMLIBS)
-	@echo $(OBJECTS)
+$(EXEC_PATH)/%: $(SRC_PATH)/%.o $(SIMLIBS)
 	SYNOPSYS_SIM_SETUP=$(TESTBENCH_PATH)/synopsys_sim.setup \
 	vcs tb glbl -j$(NPROCS) $(WRAPPER_NAME) $< -Mdirectory=$@.tmp \
 		$(VCS_LDFLAGS) $(VCS_VFLAGS) -o $@ -l $@.vcs.log

--- a/testbenches/simlibs.mk
+++ b/testbenches/simlibs.mk
@@ -50,6 +50,11 @@ ifndef LIBRARIES_PATH
 $(error $(shell echo -e "$(RED)BSG MAKE ERROR: LIBRARIES_PATH is not defined$(NC)"))
 endif
 
+# HARDWARE_PATH: The path to the hardware folder in BSG F1
+ifndef HARDWARE_PATH
+$(error $(shell echo -e "$(RED)BSG MAKE ERROR: HARDWARE_PATH is not defined$(NC)"))
+endif
+
 # PROJECT: The project name, used to as the work directory of the hardware
 # library during analysis
 ifndef PROJECT

--- a/testbenches/simlibs.mk
+++ b/testbenches/simlibs.mk
@@ -223,8 +223,8 @@ $(WORKDIR)/AN.DB: $(TESTBENCH_PATH)/synopsys_sim.setup $(CL_DIR)/Makefile.machin
 # re-built every time a regression test is compiled
 
 # Define the COSIM macro so that the DPI Versions of functions are called
-$(OBJECTS): CXXFLAGS += -DCOSIM
-$(OBJECTS): CFLAGS   += -DCOSIM
+$(LIB_OBJECTS): CXXFLAGS += -DCOSIM
+$(LIB_OBJECTS): CFLAGS   += -DCOSIM
 
 # libfpga_mgmt will be compiled in $(TESTBENCH_PATH), so direct the linker there
 $(LIBRARIES_PATH)/libbsg_manycore_runtime.so.1.0: LDFLAGS +=-L$(TESTBENCH_PATH) 


### PR DESCRIPTION
* Removed a few unnecessary checks
* Moved rule declarations to more relevant files
* Added BSG_MACHINE_NAME to all Makefile.machine.include

@vb000 @tommydcjung - Can you give input on the new BSG_MACHINE_NAME variable? I'm using this to build machine-specific crt.o files so that someone can't run with the wrong crt.o file for a machine, among other things.

@mrutt92 for LGTM
