### PR TITLE
fixes bug for multi-pod tile group eva reading

### DIFF
--- a/libraries/bsg_manycore_eva.cpp
+++ b/libraries/bsg_manycore_eva.cpp
@@ -77,6 +77,32 @@
 #define DEFAULT_DRAM_BITIDX 31
 #define DEFAULT_DRAM_BITMASK (1ULL << DEFAULT_DRAM_BITIDX)
 
+static uint32_t default_vcore_max_x_coord(const hb_mc_config_t *cfg, const hb_mc_coordinate_t *tgt)
+{
+    hb_mc_dimension_t pods = cfg->pods;
+    hb_mc_coordinate_t pod = {pods.x-1, pods.y-1};
+    hb_mc_coordinate_t og = hb_mc_config_pod_vcore_origin(cfg, pod);
+    return og.x + cfg->pod_shape.x-1;
+}
+
+static uint32_t default_vcore_min_x_coord(const hb_mc_config_t *cfg, const hb_mc_coordinate_t *tgt)
+{
+    return hb_mc_coordinate_get_x(hb_mc_config_get_origin_vcore(cfg));
+}
+
+static uint32_t default_vcore_max_y_coord(const hb_mc_config_t *cfg, const hb_mc_coordinate_t *tgt)
+{
+    hb_mc_dimension_t pods = cfg->pods;
+    hb_mc_coordinate_t pod = {pods.x-1, pods.y-1};
+    hb_mc_coordinate_t og = hb_mc_config_pod_vcore_origin(cfg, pod);
+    return og.y + cfg->pod_shape.y-1;
+}
+
+static uint32_t default_vcore_min_y_coord(const hb_mc_config_t *cfg, const hb_mc_coordinate_t *tgt)
+{
+    return hb_mc_coordinate_get_y(hb_mc_config_get_origin_vcore(cfg));
+}
+
 /**
  * Determines if an EVA is a tile-local EVA
  * @return true if EVA addresses tile-local memory, false otherwise
@@ -241,24 +267,25 @@ static int default_eva_to_npa_group(const hb_mc_config_t *cfg,
         hb_mc_dimension_t dim;
         hb_mc_idx_t x, y, ox, oy, dim_x, dim_y;
         hb_mc_epa_t epa;
-
+        hb_mc_coordinate_t pod = hb_mc_config_pod(cfg, *src);
+        hb_mc_coordinate_t og = hb_mc_config_pod_vcore_origin(cfg, pod);
         dim = hb_mc_config_get_dimension_vcore(cfg);
         dim_x = hb_mc_dimension_get_x(dim) + hb_mc_config_get_vcore_base_x(cfg);
         dim_y = hb_mc_dimension_get_y(dim) + hb_mc_config_get_vcore_base_y(cfg);
-        ox = hb_mc_coordinate_get_x(*o);
-        oy = hb_mc_coordinate_get_y(*o);
+        ox = hb_mc_coordinate_get_x(og);
+        oy = hb_mc_coordinate_get_y(og);
         x = ((hb_mc_eva_addr(eva) & DEFAULT_GROUP_X_BITMASK) >> DEFAULT_GROUP_X_BITIDX);
         x += ox;
         y = ((hb_mc_eva_addr(eva) & DEFAULT_GROUP_Y_BITMASK) >> DEFAULT_GROUP_Y_BITIDX);
         y += oy;
-        if(dim_x < x){
+        if (default_vcore_max_x_coord(cfg, src) < x || x < default_vcore_min_x_coord(cfg, src)) {
                 bsg_pr_err("%s: Invalid Group EVA. X coordinate destination %d"
                            "is larger than current manycore configuration\n",
                            __func__, x);
                 return HB_MC_FAIL;
         }
 
-        if(dim_y < y){
+        if (default_vcore_max_y_coord(cfg, src) < y || y < default_vcore_min_y_coord(cfg, src)) {
                 bsg_pr_err("%s: Invalid Group EVA. Y coordinate destination %d"
                            "is larger than current manycore configuration\n",
                            __func__, y);
@@ -270,7 +297,7 @@ static int default_eva_to_npa_group(const hb_mc_config_t *cfg,
                 return rc;
         *npa = hb_mc_epa_to_npa(hb_mc_coordinate(x,y), epa);
 
-        bsg_pr_dbg("%s: Translating EVA 0x%08" PRIx32 " for tile (x: %d y: %d) to NPA {x: %d y: %d, EPA: 0x%08" PRIx32 "}. \n",
+        bsg_pr_info("%s: Translating EVA 0x%08" PRIx32 " for tile (x: %d y: %d) to NPA {x: %d y: %d, EPA: 0x%08" PRIx32 "}. \n",
                    __func__, hb_mc_eva_addr(eva),
                    hb_mc_coordinate_get_x(*src),
                    hb_mc_coordinate_get_y(*src),

--- a/libraries/bsg_manycore_eva.cpp
+++ b/libraries/bsg_manycore_eva.cpp
@@ -297,7 +297,7 @@ static int default_eva_to_npa_group(const hb_mc_config_t *cfg,
                 return rc;
         *npa = hb_mc_epa_to_npa(hb_mc_coordinate(x,y), epa);
 
-        bsg_pr_info("%s: Translating EVA 0x%08" PRIx32 " for tile (x: %d y: %d) to NPA {x: %d y: %d, EPA: 0x%08" PRIx32 "}. \n",
+        bsg_pr_dbg("%s: Translating EVA 0x%08" PRIx32 " for tile (x: %d y: %d) to NPA {x: %d y: %d, EPA: 0x%08" PRIx32 "}. \n",
                    __func__, hb_mc_eva_addr(eva),
                    hb_mc_coordinate_get_x(*src),
                    hb_mc_coordinate_get_y(*src),

--- a/libraries/bsg_manycore_eva.cpp
+++ b/libraries/bsg_manycore_eva.cpp
@@ -79,28 +79,30 @@
 
 static uint32_t default_vcore_max_x_coord(const hb_mc_config_t *cfg, const hb_mc_coordinate_t *tgt)
 {
-    hb_mc_dimension_t pods = cfg->pods;
-    hb_mc_coordinate_t pod = {pods.x-1, pods.y-1};
+    hb_mc_coordinate_t pod = hb_mc_config_pod(cfg, *tgt);
     hb_mc_coordinate_t og = hb_mc_config_pod_vcore_origin(cfg, pod);
-    return og.x + cfg->pod_shape.x-1;
+    return hb_mc_coordinate_get_x(og) + hb_mc_dimension_get_x(cfg->pod_shape) - 1;
 }
 
 static uint32_t default_vcore_min_x_coord(const hb_mc_config_t *cfg, const hb_mc_coordinate_t *tgt)
 {
-    return hb_mc_coordinate_get_x(hb_mc_config_get_origin_vcore(cfg));
+    hb_mc_coordinate_t pod = hb_mc_config_pod(cfg, *tgt);
+    hb_mc_coordinate_t og = hb_mc_config_pod_vcore_origin(cfg, pod);
+    return hb_mc_coordinate_get_x(og);
 }
 
 static uint32_t default_vcore_max_y_coord(const hb_mc_config_t *cfg, const hb_mc_coordinate_t *tgt)
 {
-    hb_mc_dimension_t pods = cfg->pods;
-    hb_mc_coordinate_t pod = {pods.x-1, pods.y-1};
+    hb_mc_coordinate_t pod = hb_mc_config_pod(cfg, *tgt);
     hb_mc_coordinate_t og = hb_mc_config_pod_vcore_origin(cfg, pod);
-    return og.y + cfg->pod_shape.y-1;
+    return hb_mc_coordinate_get_y(og) + hb_mc_dimension_get_y(cfg->pod_shape)-1;
 }
 
 static uint32_t default_vcore_min_y_coord(const hb_mc_config_t *cfg, const hb_mc_coordinate_t *tgt)
 {
-    return hb_mc_coordinate_get_y(hb_mc_config_get_origin_vcore(cfg));
+    hb_mc_coordinate_t pod = hb_mc_config_pod(cfg, *tgt);
+    hb_mc_coordinate_t og = hb_mc_config_pod_vcore_origin(cfg, pod);
+    return hb_mc_coordinate_get_y(og);
 }
 
 /**


### PR DESCRIPTION
* Fixes a bug when translating tile-group EVAs from the host
* Before this commit, no matter what the source tile is the EVA is translated as if the source is on pod (0,0)
* After, the pod of the source core is considered when calculating the coordinate.